### PR TITLE
Name `inherit` option passed to `const_defined?` and `const_get`

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -10,19 +10,19 @@ module Phlex
   extend self
 
   def find_constant(name, relative_to:)
-    try_to_find_constant(name, relative_to:) || relative_to.const_get(name, false)
+    try_to_find_constant(name, relative_to:) || relative_to.const_get(name, _inherit = false)
     # relative_to.class_eval(name)
   end
 
   private
 
   def try_to_find_constant(name, relative_to: Module)
-    if relative_to.const_defined?(name, false)
-      relative_to.const_get(name, false)
+    if relative_to.const_defined?(name, _inherit = false)
+      relative_to.const_get(name, _inherit = false)
     elsif (parent = namespace_above(relative_to.name))
       try_to_find_constant(name, relative_to: parent)
-    elsif const_defined?("::#{name}", false)
-      const_get("::#{name}", false)
+    elsif const_defined?("::#{name}", _inherit = false)
+      const_get("::#{name}", _inherit = false)
     end
   end
 
@@ -30,8 +30,8 @@ module Phlex
     path = name.split("::")[..-2].join("::")
     return if path.empty?
 
-    if const_defined?("::#{path}")
-      const_get("::#{path}", false)
+    if const_defined?("::#{path}", _inherit = false)
+      const_get("::#{path}", _inherit = false)
     else
       namespace_above(path)
     end


### PR DESCRIPTION
Another small drive-by PR based on my personal preference to name arguments because I can never recall the method signatures for these deep Ruby methods.

Also, I'm pretty sure you simply forgot the `false` in line 33, so adding that as well.