### PR TITLE
Remove ClassCollector method_missing *args

### DIFF
--- a/lib/phlex/tag/class_collector.rb
+++ b/lib/phlex/tag/class_collector.rb
@@ -6,7 +6,7 @@ module Phlex
         @tag = tag
       end
 
-      def method_missing(name, content = nil, *args, **attributes, &block)
+      def method_missing(name, content = nil, **attributes, &block)
         @tag.classes = name
         @tag.attributes = attributes if attributes
 


### PR DESCRIPTION
This prevents the allocation of an unused Array when collecting CSS classes through `method_missing`.