### PR TITLE
Support `<template>` elements

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -18,6 +18,16 @@ module Phlex
         return super unless @_cache
         Rails.cache.fetch(self) { super }
       end
+
+      def template(...)
+        if @_rendering
+          _template_tag(...)
+        else
+          @_rendering = true
+          super
+          @_rendering = false
+        end
+      end
     end
 
     extend Cacheable

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -18,34 +18,46 @@ module Phlex
       self << component.new(*args, **kwargs, &block)
     end
 
+    def _template_tag(...)
+      _standard_element("template", ...)
+    end
+
+    def _standard_element(name, content = nil, **kwargs, &block)
+      raise ArgumentError if content && block_given?
+      tag = Tag::StandardElement.new(name, **kwargs)
+      self << tag
+
+      if block_given?
+        if block.binding.receiver.is_a?(Block)
+          block.call(tag)
+        else
+          Block.new(self, &block).call(tag)
+        end
+      end
+
+      Block.new(self) { text content }.call(tag) if content
+
+      Tag::ClassCollector.new(self, tag)
+    end
+
+    def _void_element(name, **kwargs)
+      tag = Tag::VoidElement.new(name, **kwargs)
+      self << tag
+      Tag::ClassCollector.new(self, tag)
+    end
+
     Tag::StandardElement::ELEMENTS.each do |tag_name|
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-      def #{tag_name}(content = nil, **kwargs, &block)
-          raise ArgumentError if content && block_given?
-          tag = Tag::StandardElement.new("#{tag_name}", **kwargs)
-          self << tag
-
-          if block_given?
-            if block.binding.receiver.is_a?(Block)
-              block.call(tag)
-            else
-              Block.new(self, &block).call(tag)
-            end
-          end
-
-          Block.new(self) { text content }.call(tag) if content
-
-          Tag::ClassCollector.new(self, tag)
+        def #{tag_name}(...)
+          _standard_element("#{tag_name}", ...)
         end
       RUBY
     end
 
     Tag::VoidElement::ELEMENTS.each do |tag_name|
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-        def #{tag_name}(**kwargs)
-          tag = Tag::VoidElement.new("#{tag_name}", **kwargs)
-          self << tag
-          Tag::ClassCollector.new(self, tag)
+        def #{tag_name}(...)
+          _void_element("#{tag_name}", ...)
         end
       RUBY
     end

--- a/lib/phlex/tag/standard_element.rb
+++ b/lib/phlex/tag/standard_element.rb
@@ -86,7 +86,6 @@ module Phlex
         table
         tbody
         td
-        template
         textarea
         tfoot
         th

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -280,5 +280,23 @@ RSpec.describe Phlex::Component do
         expect { output }.to raise_error(ArgumentError, "Set isn't a Phlex::Component.")
       end
     end
+
+    describe "with a template tag" do
+      let :component do
+        Class.new Phlex::Component do
+          def template
+            div do
+              h1 "A"
+              template "B"
+              h2 "C"
+            end
+          end
+        end
+      end
+
+      it "produces the correct markup" do
+        expect(output).to eq "<div><h1>A</h1><template>B</template><h2>C</h2></div>"
+      end
+    end
   end
 end


### PR DESCRIPTION
Previously, you could not use `<template>` elements in your templates because of a naming conflict. Calling the `template` method result in an infinite loop.

We overcome this here by prepending a `template` method that checks if it’s already rendering or not. If a render is already in progress, `template` acts as the DSL method, otherwise calls `super`.