### PR TITLE
Support custom elements

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -34,6 +34,20 @@ module Phlex
     include Node, Context
 
     class << self
+      def register_element(*tag_names)
+        tag_names.each do |tag_name|
+          unless tag_name.is_a? Symbol
+            raise ArgumentError, "Custom elements must be provided as Symbols"
+          end
+
+          class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+            def #{tag_name}(...)
+              _standard_element("#{tag_name.to_s.gsub('_', '-')}", ...)
+            end
+          RUBY
+        end
+      end
+
       def inherited(child)
         child.prepend(Overrides)
         super

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -298,5 +298,37 @@ RSpec.describe Phlex::Component do
         expect(output).to eq "<div><h1>A</h1><template>B</template><h2>C</h2></div>"
       end
     end
+
+    describe "with custom elements" do
+      let :component do
+        Class.new Phlex::Component do
+          register_element :trix_editor, :trix_toolbar
+
+          def template
+            div {
+              trix_toolbar
+              trix_editor "Hello"
+            }
+          end
+        end
+      end
+
+      it "produces the correct markup" do
+        expect(output).to eq "<div><trix-toolbar></trix-toolbar><trix-editor>Hello</trix-editor></div>"
+      end
+
+      describe "with invalid tags" do
+        let :component do
+          Class.new Phlex::Component do
+            register_element "NOT-VALID"
+          end
+        end
+
+        it "raises an ArgumentError" do
+          expect { component }.to raise_error(ArgumentError,
+            "Custom elements must be provided as Symbols")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
An initial prototype for supporting the definition of custom elements. Here's an example of how you might use it to build a Trix component:

```ruby
class TrixComponent < Phlex::Component
  register_element :trix_editor

  def template
    input id: "content", type: "hidden"
    trix_editor input: "content", role: "textbox"
  end
end
```

Custom elements, for now, are local to the component where they're registered.

Closes #33 