### PR TITLE
Raw node type

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -6,6 +6,10 @@ module Phlex
       self << Text.new(content)
     end
 
+    def _raw(content)
+      self << Raw.new(content)
+    end
+
     def component(component, *args, **kwargs, &block)
       unless component < Component
         raise ArgumentError, "#{component.name} isn't a Phlex::Component."

--- a/lib/phlex/raw.rb
+++ b/lib/phlex/raw.rb
@@ -1,0 +1,13 @@
+module Phlex
+  class Raw
+    include Callable
+
+    def initialize(content)
+      @content = content
+    end
+
+    def call
+      @content
+    end
+  end
+end

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -22,6 +22,20 @@ RSpec.describe Phlex::Component do
     end
   end
 
+  describe "with raw content" do
+    let :component do
+      Class.new Phlex::Component do
+        def template
+          _raw "<h1>Hi</h1>"
+        end
+      end
+    end
+
+    it "produces the correct output" do
+      expect(output).to eq "<h1>Hi</h1>"
+    end
+  end
+
   describe "with dangerous tag attributes" do
     let :component do
       Class.new Phlex::Component do

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -8,6 +8,20 @@ RSpec.describe Phlex::Component do
   let(:output) { example.call }
   let(:example) { component.new }
 
+  describe "with text" do
+    let :component do
+      Class.new Phlex::Component do
+        def template
+          text "Hi"
+        end
+      end
+    end
+
+    it "produces the correct output" do
+      expect(output).to eq "Hi"
+    end
+  end
+
   describe "with dangerous tag attributes" do
     let :component do
       Class.new Phlex::Component do


### PR DESCRIPTION
I've added a raw node type that doesn't escape HTML.

Usage:

```ruby
class ExampleComponent < Phlex::Component
  def template
    _raw "<h1>Hello</h1>"
  end
end
```

The underscore suffix is to mark this is a private method that you shouldn't really use.

I also added a spec for text nodes.