### PR TITLE
Whitespace node

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -6,6 +6,10 @@ module Phlex
       self << Text.new(content)
     end
 
+    def whitespace
+      _raw(" ")
+    end
+
     def _raw(content)
       self << Raw.new(content)
     end

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe Phlex::Component do
     end
   end
 
+  describe "with whitespace" do
+    let :component do
+      Class.new Phlex::Component do
+        def template
+          a "Home"
+          whitespace
+          a "About"
+        end
+      end
+    end
+
+    it "produces the correct output" do
+      expect(output).to eq "<a>Home</a> <a>About</a>"
+    end
+  end
+
   describe "with dangerous tag attributes" do
     let :component do
       Class.new Phlex::Component do


### PR DESCRIPTION
Added a `whitespace` node for when you need to insert whitespace between two elements. For example:

```ruby
class ExampleComponent < Phlex::Component
  def template
    a "Home"
    whitespace
    a "About"
  end
end
```