### PR TITLE
Use fewer strings

### DIFF
--- a/lib/phlex/block.rb
+++ b/lib/phlex/block.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Phlex
   class Block
     include Callable

--- a/lib/phlex/callable.rb
+++ b/lib/phlex/callable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Phlex
   module Callable
     def call

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "digest"
 
 module Phlex
@@ -47,7 +48,7 @@ module Phlex
       attributes.each { |k, v| instance_variable_set("@#{k}", v) }
     end
 
-    def call
+    def call(buffer = String.new)
       raise "The same component instance shouldn't be rendered twice" if @_rendered
       @_rendered = true
 

--- a/lib/phlex/configuration.rb
+++ b/lib/phlex/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Phlex
   class Configuration
     attr_accessor :convert_underscores_to_dashes

--- a/lib/phlex/node.rb
+++ b/lib/phlex/node.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Phlex
   module Node
     include Callable
@@ -6,8 +8,9 @@ module Phlex
       @_children ||= []
     end
 
-    def call
-      children.map(&:call).join
+    def call(buffer = String.new)
+      children.each { _1.call(buffer) }
+      buffer
     end
   end
 end

--- a/lib/phlex/raw.rb
+++ b/lib/phlex/raw.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Phlex
   class Raw
     include Callable
@@ -6,8 +8,8 @@ module Phlex
       @content = content
     end
 
-    def call
-      @content
+    def call(buffer = String.new)
+      buffer << @content
     end
   end
 end

--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -37,10 +37,6 @@ module Phlex
 
     private
 
-    def opening_tag_content
-      name + attributes
-    end
-
     def attributes
       attributes = @attributes.dup
       attributes[:class] = classes

--- a/lib/phlex/tag/class_collector.rb
+++ b/lib/phlex/tag/class_collector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Phlex
   class Tag
     class ClassCollector < BasicObject

--- a/lib/phlex/tag/standard_element.rb
+++ b/lib/phlex/tag/standard_element.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Phlex
   class Tag
     class StandardElement < Tag
@@ -99,8 +101,10 @@ module Phlex
         wbr
       ].freeze
 
-      def call
-        "<#{opening_tag_content}>#{super}</#{name}>"
+      def call(buffer = String.new)
+        buffer << "<" << name << attributes << ">"
+        super
+        buffer << "</" << name << ">"
       end
     end
   end

--- a/lib/phlex/tag/void_element.rb
+++ b/lib/phlex/tag/void_element.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Phlex
   class Tag
     class VoidElement < Tag
@@ -13,8 +15,8 @@ module Phlex
         col
       ].freeze
 
-      def call
-        "<#{opening_tag_content} />"
+      def call(buffer = String.new)
+        buffer << "<" << name << attributes << " />"
       end
     end
   end

--- a/lib/phlex/text.rb
+++ b/lib/phlex/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Phlex
   class Text
     include Callable
@@ -6,8 +8,8 @@ module Phlex
       @content = content
     end
 
-    def call
-      ERB::Util.html_escape(@content)
+    def call(buffer = String.new)
+      buffer << ERB::Util.html_escape(@content)
     end
   end
 end


### PR DESCRIPTION
Elements pass a buffer string around and append to it instead of returning their own strings for joining.

In theory, this means we can yield to an enumerator for streaming responses. (See #41)

```ruby
Enumerator.new { |buffer| component.call(buffer) }
```