### PR TITLE
Strip `javascript:` from href attribute of anchor elements

### DIFF
--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -45,7 +45,7 @@ module Phlex
       attributes = @attributes.dup
       attributes[:class] = classes
       attributes.compact!
-      attributes[:href] = attributes[:href].gsub("javascript:", "") if attributes[:href]
+      attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
       attributes.transform_values! { ERB::Util.html_escape(_1) }
       attributes = attributes.map { |k, v| %Q(#{k}="#{v}") }.join(SPACE)
       attributes.prepend(SPACE) unless attributes.empty?

--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -45,6 +45,7 @@ module Phlex
       attributes = @attributes.dup
       attributes[:class] = classes
       attributes.compact!
+      attributes[:href] = attributes[:href].gsub("javascript:", "") if attributes[:href]
       attributes.transform_values! { ERB::Util.html_escape(_1) }
       attributes = attributes.map { |k, v| %Q(#{k}="#{v}") }.join(SPACE)
       attributes.prepend(SPACE) unless attributes.empty?

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe Phlex::Component do
     end
   end
 
+  describe "with javascript link protocol in hypertext reference" do
+    let :component do
+      Class.new Phlex::Component do
+        def template
+          a "Javascript link", href: "javascript:javascript:alert(1)"
+        end
+      end
+    end
+
+    it "produces link by striping javascript:" do
+      expect(output).to have_tag :a, with: { href: "alert(1)" }
+    end
+  end
+
   describe "with a standard HTML element" do
     let :component do
       Class.new Phlex::Component do


### PR DESCRIPTION
- Strip `javascript:` from `href` attribute of `anchor` elements

Closes #5 