### PR TITLE
The same component instance shouldn't be rendered twice

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -98,6 +98,9 @@ module Phlex
     end
 
     def call
+      raise "The same component instance shouldn't be rendered twice" if @_rendered
+      @_rendered = true
+
       template(&@_content)
       super
     end

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -284,6 +284,22 @@ RSpec.describe Phlex::Component do
     end
   end
 
+  describe "rendering the same component twice" do
+    let :component do
+      Class.new Phlex::Component do
+        def template
+          h1 "Rendered twice"
+        end
+      end
+    end
+
+    it "raises an error" do
+      instance = component.new
+
+      expect { 2.times { instance.call } }.to raise_error("The same component instance shouldn't be rendered twice")
+    end
+  end
+
   describe "with a nested component" do
     describe "with nested content" do
       let :component do


### PR DESCRIPTION
Closes #43 

In this PR, we prevent a single instance of a component to be rendered twice. This is because, when a component is rendered, instance variables such as `@_children` are set and never cleaned up.

To avoid any confusion, we raise an error when attempting to render the same component instance twice.