### PR TITLE
Strip `javascript:` protocol only after HTML escaping

### DIFF
--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -41,8 +41,8 @@ module Phlex
       attributes = @attributes.dup
       attributes[:class] = classes
       attributes.compact!
-      attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
       attributes.transform_values! { CGI.escape_html(_1) }
+      attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
       attributes = attributes.map { |k, v| %Q(#{k}="#{v}") }.join(SPACE)
       attributes.prepend(SPACE) unless attributes.empty?
       attributes

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Phlex::Component do
       end
     end
 
-    it "produces link by striping javascript:" do
+    it "strips the javascript protocol" do
       expect(output).to have_tag :a, with: { href: "alert(1)" }
     end
   end


### PR DESCRIPTION
I realised it _might_ be possible to format a string such that that it is not stripped by our regular expression but the HTML escaper upgrades it. If the html escaper converts some character to a `:` to prevent some other attack, the order of these operations could be exploited.

For example `javascript：alert(1)` will not stripped by our regular expression because `：` is not `:`. If the HTML escaper converts `：` to `:` then it will become `javascript:alert(1)`.

I haven't been able to find an actual workaround to our existing setup so this is just precautionary.