### PR TITLE
Switch to the `escape_html` method provided by `CGI`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,26 +2,16 @@ PATH
   remote: .
   specs:
     phlex (0.1.0)
-      activesupport (~> 7.0)
       zeitwerk (~> 2.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
     benchmark-ips (2.10.0)
     benchmark-memory (0.2.0)
       memory_profiler (~> 1)
-    concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
-    i18n (1.10.0)
-      concurrent-ruby (~> 1.0)
     memory_profiler (1.0.0)
-    minitest (5.15.0)
     nokogiri (1.13.6-arm64-darwin)
       racc (~> 1.4)
     racc (1.6.0)
@@ -42,8 +32,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
-    tzinfo (2.0.4)
-      concurrent-ruby (~> 1.0)
     zeitwerk (2.6.0)
 
 PLATFORMS

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/string/output_safety"
+require "cgi"
 require "zeitwerk"
 
 loader = Zeitwerk::Loader.for_gem

--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -42,7 +42,7 @@ module Phlex
       attributes[:class] = classes
       attributes.compact!
       attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
-      attributes.transform_values! { ERB::Util.html_escape(_1) }
+      attributes.transform_values! { CGI.escape_html(_1) }
       attributes = attributes.map { |k, v| %Q(#{k}="#{v}") }.join(SPACE)
       attributes.prepend(SPACE) unless attributes.empty?
       attributes

--- a/lib/phlex/text.rb
+++ b/lib/phlex/text.rb
@@ -9,7 +9,7 @@ module Phlex
     end
 
     def call(buffer = String.new)
-      buffer << ERB::Util.html_escape(@content)
+      buffer << CGI.escape_html(@content)
     end
   end
 end

--- a/phlex.gemspec
+++ b/phlex.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
 
-  spec.add_dependency "activesupport", "~> 7.0"
   spec.add_dependency "zeitwerk", "~> 2.6"
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
This removes our dependency on ActiveSupport / Nokogiri and also makes our nav benchmark ~11% faster.

Before
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
        NavComponent     3.994k i/100ms
Calculating -------------------------------------
        NavComponent     39.980k (± 0.4%) i/s -    203.694k in   5.095005s
```

After
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
        NavComponent     4.474k i/100ms
Calculating -------------------------------------
        NavComponent     44.730k (± 0.8%) i/s -    223.700k in   5.001379s
```