### PR TITLE
Optimize delegation

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -48,14 +48,15 @@ module Phlex
       Tag::ClassCollector.new(self, tag)
     end
 
-    def _void_element(name, **kwargs)
-      tag = Tag::VoidElement.new(name, **kwargs)
+    def _void_element(**kwargs)
+      tag = Tag::VoidElement.new(__callee__.name, **kwargs)
       self << tag
       Tag::ClassCollector.new(self, tag)
     end
 
     Tag::StandardElement::ELEMENTS.each do |tag_name|
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        # frozen_string_literal: true
         def #{tag_name}(...)
           _standard_element("#{tag_name}", ...)
         end
@@ -63,11 +64,7 @@ module Phlex
     end
 
     Tag::VoidElement::ELEMENTS.each do |tag_name|
-      class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-        def #{tag_name}(...)
-          _void_element("#{tag_name}", ...)
-        end
-      RUBY
+      alias_method tag_name, :_void_element
     end
   end
 end


### PR DESCRIPTION
For _void_element we can directly use `alias_method` and then use `__callee__.name` to know which tag to generate.

This way it saves a method call, with `...` delegation which isn't that fast.

Unfortunately `_standard_element` can't be delegated this way because of the `template` method. However we can enable `frozen_string_literal: true` in `class_eval` to save a string allocation per call.