### PR TITLE
Rename `Node` -> `ParentNode`

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -21,7 +21,7 @@ module Phlex
       end
     end
 
-    include Node, Context
+    include ParentNode, Context
 
     class << self
       def register_element(*tag_names)

--- a/lib/phlex/parent_node.rb
+++ b/lib/phlex/parent_node.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Phlex
-  module Node
+  module ParentNode
     include Callable
 
     def children

--- a/lib/phlex/tag/standard_element.rb
+++ b/lib/phlex/tag/standard_element.rb
@@ -3,7 +3,7 @@
 module Phlex
   class Tag
     class StandardElement < Tag
-      include Node
+      include ParentNode
 
       ELEMENTS = %w[
         a


### PR DESCRIPTION
Node doesn't feel like the right name for this as not all nodes have children so they don't all include `Node`. I’m not entirely sure if `Branch` is the right name either so let me know if you can think of anything else.