### PR TITLE
Optimize delegation

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -31,8 +31,8 @@ module Phlex
           end
 
           class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-            def #{tag_name}(...)
-              _standard_element("#{tag_name.to_s.gsub('_', '-')}", ...)
+            def #{tag_name}(*args, **kwargs, &)
+              _standard_element(*args, _name: "#{tag_name.to_s.gsub('_', '-')}", **kwargs, &)
             end
           RUBY
         end

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -48,14 +48,15 @@ module Phlex
       Tag::ClassCollector.new(self, tag)
     end
 
-    def _void_element(name, **kwargs)
-      tag = Tag::VoidElement.new(name, **kwargs)
+    def _void_element(**kwargs)
+      tag = Tag::VoidElement.new(__callee__.name, **kwargs)
       self << tag
       Tag::ClassCollector.new(self, tag)
     end
 
     Tag::StandardElement::ELEMENTS.each do |tag_name|
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        # frozen_string_literal: true
         def #{tag_name}(...)
           _standard_element("#{tag_name}", ...)
         end
@@ -63,11 +64,7 @@ module Phlex
     end
 
     Tag::VoidElement::ELEMENTS.each do |tag_name|
-      class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-        def #{tag_name}(...)
-          _void_element("#{tag_name}", ...)
-        end
-      RUBY
+      alias_method tag_name, :_void_element
     end
   end
 end

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -26,12 +26,14 @@ module Phlex
       self << component.new(*args, **kwargs, &block)
     end
 
-    def _template_tag(...)
-      _standard_element("template", ...)
+    def _template_tag(*args, **kwargs, &)
+      _standard_element(*args, _name: "template", **kwargs, &)
     end
 
-    def _standard_element(name, content = nil, **kwargs, &block)
+    def _standard_element(content = nil, _name: nil, **kwargs, &block)
       raise ArgumentError if content && block_given?
+
+      name = _name ||= __callee__.name
       tag = Tag::StandardElement.new(name, **kwargs)
       self << tag
 
@@ -55,12 +57,7 @@ module Phlex
     end
 
     Tag::StandardElement::ELEMENTS.each do |tag_name|
-      class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-        # frozen_string_literal: true
-        def #{tag_name}(...)
-          _standard_element("#{tag_name}", ...)
-        end
-      RUBY
+      alias_method tag_name, :_standard_element
     end
 
     Tag::VoidElement::ELEMENTS.each do |tag_name|


### PR DESCRIPTION
@byroot opened a PR (#50) to optimise delegating by using `alias_method` with `__callee__.name` instead of delegating with `...`. Building on that, I found a way to apply it to the `_standard_elements` by making the `name` argument optional. This optimisation makes the nav benchmark ~3% faster.

Before

```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
        NavComponent     4.441k i/100ms
Calculating -------------------------------------
        NavComponent     44.677k (± 0.4%) i/s -    226.491k in   5.069581s
```

After

```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
        NavComponent     4.593k i/100ms
Calculating -------------------------------------
        NavComponent     46.011k (± 0.4%) i/s -    234.243k in   5.091106s
```

Closes #50 