### PR TITLE
Use UTF-8 buffers

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -48,7 +48,7 @@ module Phlex
       attributes.each { |k, v| instance_variable_set("@#{k}", v) }
     end
 
-    def call(buffer = String.new)
+    def call(buffer = +"")
       raise "The same component instance shouldn't be rendered twice" if @_rendered
       @_rendered = true
 

--- a/lib/phlex/node.rb
+++ b/lib/phlex/node.rb
@@ -8,7 +8,7 @@ module Phlex
       @_children ||= []
     end
 
-    def call(buffer = String.new)
+    def call(buffer = +"")
       children.each { _1.call(buffer) }
       buffer
     end

--- a/lib/phlex/raw.rb
+++ b/lib/phlex/raw.rb
@@ -8,7 +8,7 @@ module Phlex
       @content = content
     end
 
-    def call(buffer = String.new)
+    def call(buffer = +"")
       buffer << @content
     end
   end

--- a/lib/phlex/tag/standard_element.rb
+++ b/lib/phlex/tag/standard_element.rb
@@ -101,7 +101,7 @@ module Phlex
         wbr
       ].freeze
 
-      def call(buffer = String.new)
+      def call(buffer = +"")
         buffer << "<" << name << attributes << ">"
         super
         buffer << "</" << name << ">"

--- a/lib/phlex/tag/void_element.rb
+++ b/lib/phlex/tag/void_element.rb
@@ -15,7 +15,7 @@ module Phlex
         col
       ].freeze
 
-      def call(buffer = String.new)
+      def call(buffer = +"")
         buffer << "<" << name << attributes << " />"
       end
     end

--- a/lib/phlex/text.rb
+++ b/lib/phlex/text.rb
@@ -8,7 +8,7 @@ module Phlex
       @content = content
     end
 
-    def call(buffer = String.new)
+    def call(buffer = +"")
       buffer << CGI.escape_html(@content)
     end
   end


### PR DESCRIPTION
`String.new` isn't a good way to create a buffer, or at least not for HTML templating which is likely to produce UTF-8.

`String.new` creates a binary string:

```ruby
>> String.new.encoding
=> #<Encoding:ASCII-8BIT>
```

Since your final string should be UTF-8, it's better to do the buffering with UTF-8 strings.