### PR TITLE
Treat component's first positional argument as text

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -23,7 +23,11 @@ module Phlex
         block = Block.new(self, &block)
       end
 
-      self << component.new(*args, **kwargs, &block)
+      if args.one? && !block_given?
+        self << component.new(**kwargs) { text(args.first) }
+      else
+        self << component.new(*args, **kwargs, &block)
+      end
     end
 
     def _template_tag(*args, **kwargs, &)

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -405,4 +405,18 @@ RSpec.describe Phlex::Component do
       end
     end
   end
+
+  describe "with a positional argument" do
+    let(:component) do
+      Class.new Phlex::Component do
+        def template
+          component CardComponent, "Hello World!"
+        end
+      end
+    end
+
+    it "produces the correct markup" do
+      expect(output).to eq %{<article class="p-5 rounded drop-shadow">Hello World!</article>}
+    end
+  end
 end


### PR DESCRIPTION
Closes #56

Thanks to this commit, given this component:

```rb
class HeaderComponent < Phlex::Component
  def template(&)
    h1.text_xl(&)
  end
end
```

We are able to use it like this:

```rb
component HeaderComponent, "Hello World!"
```