### PR TITLE
Fix CSS class with frozen string

### DIFF
--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -11,7 +11,7 @@ module Phlex
 
     def initialize(name, **attributes)
       @name = name
-      @classes = String.new
+      @classes = +""
       self.attributes = attributes
     end
 
@@ -23,11 +23,11 @@ module Phlex
     def classes=(value)
       case value
       when String
-        @classes << value.prepend(SPACE)
+        @classes << SPACE << value
       when Symbol
-        @classes << value.to_s.prepend(SPACE)
+        @classes << SPACE << value.to_s
       when Array
-        @classes << value.join(SPACE).prepend(SPACE)
+        value.each { @classes << SPACE << _1 }
       when nil
         return
       else

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CardComponent < Phlex::Component
   def template(&)
     article.p_5.rounded.drop_shadow(&)


### PR DESCRIPTION
Closes #60 and also improves performance.

Before:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
        NavComponent     4.648k i/100ms
Calculating -------------------------------------
        NavComponent     46.367k (± 0.4%) i/s -    232.400k in   5.012298s
```

After:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
        NavComponent     4.644k i/100ms
Calculating -------------------------------------
        NavComponent     46.789k (± 0.2%) i/s -    236.844k in   5.062034s
```