### PR TITLE
Component constant methods

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -7,7 +7,13 @@ loader = Zeitwerk::Loader.for_gem
 loader.setup
 
 module Phlex
+  NAMESPACE_DELINEATOR = "::"
   extend self
+
+  def find_constant(name, relative_to:)
+    try_to_find_constant(name, relative_to:) || relative_to.const_get(name, _inherit = false)
+    # relative_to.class_eval(name)
+  end
 
   def configuration
     @configuration ||= Configuration.new
@@ -15,5 +21,42 @@ module Phlex
 
   def configure
     yield configuration
+  end
+
+  private
+
+  def try_to_find_constant(name, relative_to: Module)
+    if relative_to.const_defined?(name, _inherit = false)
+     relative_to.const_get(name, _inherit = false)
+    elsif (parent = namespace_above(relative_to.name))
+     try_to_find_constant(name, relative_to: parent)
+    elsif const_defined?("::#{name}", _inherit = false)
+     const_get("::#{name}", _inherit = false)
+    end
+  end
+
+  # Given:
+  #
+  #  module A
+  #    module B; end
+  #  end
+  #
+  # Then:
+  #
+  #  > namespace_above('A::B')
+  #  => A
+  #  > namespace_above('A::B::Foo')
+  #  => A::B
+  #  > namespace_above('A::B::Foo::Bar')
+  #  => A::B
+  def namespace_above(name)
+    path = name.split("::")[..-2].join("::")
+    return if path.empty?
+
+    if const_defined?("::#{path}", _inherit = false)
+     const_get("::#{path}", _inherit = false)
+    else
+     namespace_above(path)
+    end
   end
 end

--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -5,7 +5,6 @@ module Phlex
     DASH = "-"
     SPACE = " "
     UNDERSCORE = "_"
-    NAMESPACE_DELINEATOR = "::"
 
     attr_reader :name
 

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -4,6 +4,43 @@ class CardComponent < Phlex::Component
   end
 end
 
+class Example < Phlex::Component
+  def template
+    CardComponent do
+      h1 "Hi"
+    end
+  end
+end
+
+class Table < Phlex::Component
+  def template(&)
+    table(&)
+  end
+
+  class Row < Phlex::Component
+    def template(&)
+      tr(&)
+    end
+  end
+
+  class Column < Phlex::Component
+    def template(&)
+      td(&)
+    end
+  end
+
+  class Fabricator < Phlex::Component
+    def template(&)
+      Table {
+        Row {
+          Column { text "Hello" }
+        }
+      }
+    end
+  end
+end
+
+
 RSpec.describe Phlex::Component do
   let(:output) { example.call }
   let(:example) { component.new }
@@ -402,6 +439,23 @@ RSpec.describe Phlex::Component do
           expect { component }.to raise_error(ArgumentError,
             "Custom elements must be provided as Symbols")
         end
+      end
+    end
+
+    describe "with constant methods" do
+      let(:component) { Example }
+
+      it "produces the correct output" do
+        expect(output).to have_tag :article
+        expect(output).to have_tag :h1, text: "Hi"
+      end
+    end
+
+    describe "with complex nesting constant methods" do
+      let(:component) { Table::Fabricator }
+
+      it "produces the correct output" do
+        expect(output).to eq("")
       end
     end
   end


### PR DESCRIPTION
This was an early attempt at supporting using components with methods that map to their constant names. Unfortunately we discovered Symbols can't contain `:`.