### PR TITLE
Use String#<< to make attributes faster

### DIFF
--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -37,15 +37,14 @@ module Phlex
 
     private
 
-    def attributes
+    def attributes(buffer = +"")
       attributes = @attributes.dup
       attributes[:class] = classes
       attributes.compact!
       attributes.transform_values! { CGI.escape_html(_1) }
       attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
-      attributes = attributes.map { |k, v| %Q(#{k}="#{v}") }.join(SPACE)
-      attributes.prepend(SPACE) unless attributes.empty?
-      attributes
+      attributes.each { |k, v| buffer << SPACE << k.name << '="' << v << '"' }
+      buffer
     end
 
     def classes

--- a/lib/phlex/tag/standard_element.rb
+++ b/lib/phlex/tag/standard_element.rb
@@ -102,7 +102,9 @@ module Phlex
       ].freeze
 
       def call(buffer = +"")
-        buffer << "<" << name << attributes << ">"
+        buffer << "<" << name
+        attributes(buffer)
+        buffer << ">"
         super
         buffer << "</" << name << ">"
       end

--- a/lib/phlex/tag/void_element.rb
+++ b/lib/phlex/tag/void_element.rb
@@ -16,7 +16,9 @@ module Phlex
       ].freeze
 
       def call(buffer = +"")
-        buffer << "<" << name << attributes << " />"
+        buffer << "<" << name
+        attributes(buffer)
+        buffer << " />"
       end
     end
   end


### PR DESCRIPTION
Before:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
        NavComponent     4.644k i/100ms
Calculating -------------------------------------
        NavComponent     46.789k (± 0.2%) i/s -    236.844k in   5.062034s
```

After:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
        NavComponent     4.947k i/100ms
Calculating -------------------------------------
        NavComponent     49.665k (± 1.5%) i/s -    252.297k in   5.081184s
```