### PR TITLE
Cache CSS classes on ClassCollector

### DIFF
--- a/lib/phlex/tag/class_collector.rb
+++ b/lib/phlex/tag/class_collector.rb
@@ -8,21 +8,29 @@ module Phlex
         @tag = tag
       end
 
-      def method_missing(name, content = nil, **attributes, &block)
-        @tag.classes = name
+      define_method :__class__, ::Kernel.instance_method(:class)
+      define_method :__callee__, ::Kernel.instance_method(:__callee__)
+
+      def __add_class__(content = nil, **attributes, &block)
+        @tag.classes = __callee__.name
         @tag.attributes = attributes if attributes
 
         if ::Kernel.block_given?
           if block.binding.receiver.is_a?(Block)
             block.call(@tag)
           else
-            Block.new(@context, &block).call(@tag)
+            ::Phlex::Block.new(@context, &block).call(@tag)
           end
         end
 
-        Block.new(@context) { text content }.call(@tag) if content
+        ::Phlex::Block.new(@context) { text content }.call(@tag) if content
 
         self
+      end
+
+      def method_missing(name, content = nil, **attributes, &block)
+        __class__.alias_method(name, :__add_class__)
+        __send__(name, content, **attributes, &block)
       end
     end
   end


### PR DESCRIPTION
This PR improves performance of the `ClassCollector` when a CSS class is re-used. Closes #54 

### How it works

The `ClassCollector` picks up CSS classes through method chaining on an element. For example, if we want to add the CSS classes `text-xl` and `font-bold` to an `<h1>` tag, we could write the following:

```ruby
h1.text_xl.font_bold "Hello World!"
```

Because there's no way to know ahead-of-time that `text_xl` and `font_bold` will be called on the `h1`, these method calls are picked up through `method_missing`. Unfortunately, `method_missing` is quite slow so now we make a new alias for that missing method the first time it's called so it's not missing the next time if the same CSS class is used elsewhere.

We don't have a benchmark that really showcases this, but it definitely improves performance when CSS classes are used more than once with method chaining.