### PR TITLE
Fix Rakefile to invoke rspec not minitest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 
 require "bundler/gem_tasks"
-require "rake/testtask"
 
-Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList["test/**/test_*.rb"]
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
 end
 
-task default: :test
+task default: :spec


### PR DESCRIPTION
This gets me every time. Now `bundle exec rake` runs the test suite rather than being a noop.