### PR TITLE
Implement Phlex::Component#render_in

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -55,6 +55,10 @@ module Phlex
       template(&@_content)
       super
     end
+    
+    def render_in(_view_context)
+      call
+    end
 
     def target
       @_target || self


### PR DESCRIPTION
References #1, #68

Allows Phlex::Component instances to be passed to the `render` view helper in Rails.

Currently this is just an alias for `#call` with no arguments, and as such it completely ignores the view context argument.

However, there was some discussion on Discord about maybe supporting capturing blocks like:

```rb
<%= render MyComponent.new do %>
  other ERB content
<% end %>
```

This is not super hard to implement if there's interest, but I'm not sure if it will conflict or be confused with other, more idiomatic, uses of passing blocks to Phlex components. (e.g. the table fabricator example).
