### PR TITLE
Fix issue with component subclass template method

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -16,7 +16,12 @@ module Phlex
       end
 
       def template(...)
-        if @_rendering
+        called_from = caller_locations(1,1)[0].label.to_sym
+
+        # If we're rendering a template and not being called from
+        # another override in the ancestry, we render the template tag.
+
+        if @_rendering && (called_from != __method__)
           _template_tag(...)
         else
           @_rendering = true

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe Phlex::Component do
     end
   end
 
+  describe "when subclassing another component" do
+    let(:component) { Class.new CardComponent }
+
+    it "produces the correct output" do
+      expect(output).to eq %{<article class=\"p-5 rounded drop-shadow\"></article>}
+    end
+  end
+
   describe "with text" do
     let :component do
       Class.new Phlex::Component do


### PR DESCRIPTION
If you subclassed a component but didn't override the `template` method, the component would always return `<template></template>` because there would be two `template` overrides from `Phlex::Component::Override` stacked on top of each other.

Here's what the ancestry looks like when one component subclasses another.

```
[Phlex::Component::Overrides,                                                                                                 
 #<Class:0x0000000107950990>,
 Phlex::Component::Overrides,
 CardComponent,
 Phlex::Component,
 Phlex::ParentNode,
 Phlex::Callable,
 Phlex::Context,
 Phlex::Rails::Renderable,
 ActiveSupport::Dependencies::RequireDependency,
 ActiveSupport::ToJsonWithActiveSupportEncoder,
 Object,
 PP::ObjectMixin,
 ActiveSupport::Tryable,
 JSON::Ext::Generator::GeneratorMethods::Object,
 Kernel,
 BasicObject]
```

This fix works because the override checks if the caller was itself and otherwise calls `super`.

I’m not sure if there's a better way to do this. I thought using `caller_locations` would significantly impact the performance but it doesn't seem to have made a big difference.