### PR TITLE
Simplify tag attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,35 +161,6 @@ end
 
 This badge component takes a color argument and uses [Ecase](https://github.com/joeldrapper/ecase) to build a list of Tailwind classes.
 
-```ruby
-class BadgeComponent < Phlex::Component
-  VALID_COLORS = [:sky, :teal, :rose, :slate, :orange]
-
-  def initialize(color:)
-    super
-  end
-
-  def template(&)
-    span(class:, &)
-  end
-
-  private
-
-  def class
-    [:px_1, :py_1, :rounded_full, :text_sm] + colors
-  end
-
-  def colors
-    ecase @color, VALID_COLORS do
-      on(:sky) { [:bg_sky_200, :ring_sky_300, :text_sky_900] }
-      on(:teal) { [:bg_teal_100, :ring_teal_200, :text_teal_800] }
-      on(:rose) { [:bg_rose_100, :ring_rose_200, :text_rose_900] }
-      on(:slate) { [:bg_slate_200, :ring_slate_300, :text_slate_800] }
-      on(:orange) { [:bg_orange_200, :ring_orange_300, :text_orange_900] }
-    end
-  end
-end
-```
 
 ## Installation
 

--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -11,46 +11,16 @@ module Phlex
 
     def initialize(name, **attributes)
       @name = name
-      @classes = +""
-      self.attributes = attributes
-    end
-
-    def attributes=(attributes)
-      self.classes = attributes.delete(:class)
       @attributes = attributes
-    end
-
-    def classes=(value)
-      case value
-      when String
-        @classes << SPACE << value
-      when Symbol
-        @classes << SPACE << value.to_s
-      when Array
-        value.each { @classes << SPACE << _1 }
-      when nil
-        return
-      else
-        raise ArgumentError, "Classes must be String, Symbol, or Array<String>."
-      end
     end
 
     private
 
     def attributes(buffer = +"")
-      attributes = @attributes.dup
-      attributes[:class] = classes
-      attributes.compact!
-      attributes.transform_values! { CGI.escape_html(_1) }
-      attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
-      attributes.each { |k, v| buffer << SPACE << k.name << '="' << v << '"' }
+      @attributes.transform_values! { CGI.escape_html(_1) }
+      @attributes[:href].sub!(/^\s*(javascript:)+/, "") if @attributes[:href]
+      @attributes.each { |k, v| buffer << SPACE << k.name << '="' << v << '"' }
       buffer
-    end
-
-    def classes
-      return if @classes.empty?
-      @classes.strip!
-      @classes
     end
   end
 end

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -213,20 +213,6 @@ RSpec.describe Phlex::Component do
     end
   end
 
-  describe "with an Array<String> of classes" do
-    let :component do
-      Class.new Phlex::Component do
-        def template
-          div class: %w(a b c)
-        end
-      end
-    end
-
-    it "produces the classes" do
-      expect(output).to eq %{<div class="a b c"></div>}
-    end
-  end
-
   describe "with component attributes" do
     let :component do
       Class.new Phlex::Component do


### PR DESCRIPTION
We don't need this special handling of CSS classes now that we don't support method chaining. #73 

Before:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    18.000  i/100ms
Calculating -------------------------------------
                Page    182.792  (± 0.5%) i/s -      3.672k in  20.089634s
```

After:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    22.000  i/100ms
Calculating -------------------------------------
                Page    227.200  (± 0.4%) i/s -      4.554k in  20.044099s
```
