### PR TITLE
Render to children String buffer immediately

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -70,10 +70,6 @@ module Phlex
       @_target || self
     end
 
-    def <<(node)
-      target.children << node
-    end
-
     def content
       yield(target) if block_given?
     end

--- a/lib/phlex/parent_node.rb
+++ b/lib/phlex/parent_node.rb
@@ -5,12 +5,11 @@ module Phlex
     include Callable
 
     def children
-      @_children ||= []
+      @_children ||= +""
     end
 
     def call(buffer = +"")
-      children.each { _1.call(buffer) }
-      buffer
+      buffer << children
     end
   end
 end


### PR DESCRIPTION
Instead of first building a tree of elements and then rendering that tree, we render each element to a string buffer immediately. This brings a significant performance improvement and makes way for a compiler method to do simple String appends from the compiled template method.

Before:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    22.000  i/100ms
Calculating -------------------------------------
                Page    236.390  (± 1.3%) i/s -      1.188k in   5.026415s
```

After:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    25.000  i/100ms
Calculating -------------------------------------
                Page    251.364  (± 0.0%) i/s -      1.275k in   5.072336s
```