### PR TITLE
Named Tag symbols

### DIFF
--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -7,6 +7,11 @@ module Phlex
     UNDERSCORE = "_"
     NAMESPACE_DELINEATOR = "::"
 
+    LEFT = "<"
+    RIGHT = ">"
+    CLOSE_LEFT = "</"
+    CLOSE_VOID_RIGHT = " />"
+
     attr_reader :name
 
     def initialize(name, **attributes)

--- a/lib/phlex/tag/standard_element.rb
+++ b/lib/phlex/tag/standard_element.rb
@@ -102,11 +102,11 @@ module Phlex
       ].freeze
 
       def call(buffer = +"")
-        buffer << "<" << name
+        buffer << LEFT << name
         attributes(buffer)
-        buffer << ">"
+        buffer << RIGHT
         super
-        buffer << "</" << name << ">"
+        buffer << CLOSE_LEFT << name << RIGHT
       end
     end
   end

--- a/lib/phlex/tag/void_element.rb
+++ b/lib/phlex/tag/void_element.rb
@@ -16,9 +16,9 @@ module Phlex
       ].freeze
 
       def call(buffer = +"")
-        buffer << "<" << name
+        buffer << LEFT << name
         attributes(buffer)
-        buffer << " />"
+        buffer << CLOSE_VOID_RIGHT
       end
     end
   end


### PR DESCRIPTION
Tag symbols, like `<`, `>`, `</` and ` />` are now constant frozen strings. This is a very minor performance improvement but every little counts.