### PR TITLE
Cache tag attributes from their hash value

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -9,6 +9,8 @@ loader.setup
 module Phlex
   extend self
 
+  ATTRIBUTE_CACHE = {}
+
   def configuration
     @configuration ||= Configuration.new
   end

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -32,6 +32,8 @@ module Phlex
     end
 
     class << self
+      attr_accessor :rendered_at_least_once
+
       def register_element(*tag_names)
         tag_names.each do |tag_name|
           unless tag_name.is_a? Symbol
@@ -62,6 +64,7 @@ module Phlex
 
       @_target = buffer
       template(&@_content)
+      self.class.rendered_at_least_once ||= true
       buffer
     end
   end

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -68,9 +68,24 @@ module Phlex
     end
 
     def _attributes(attributes)
+      if (cached = Phlex::ATTRIBUTE_CACHE[attributes.hash])
+        return @_target << cached
+      end
+
+      first_render = !self.class.rendered_at_least_once
+
+      buffer = first_render ? buffer = +"" : buffer = @_target
+
       attributes.transform_values! { CGI.escape_html(_1) }
       attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
-      attributes.each { |k, v| @_target << Tag::SPACE << k.name << '="' << v << '"' }
+
+      attributes.each do |k, v|
+        buffer << Tag::SPACE << k.name << Tag::EQUALS_QUOTE << v << Tag::QUOTE
+      end
+
+      if first_render
+        @_target << Phlex::ATTRIBUTE_CACHE[attributes.hash] = buffer.freeze
+      end
     end
 
     Tag::STANDARD_ELEMENTS.each do |tag_name|

--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -12,6 +12,9 @@ module Phlex
     CLOSE_LEFT = "</"
     CLOSE_VOID_RIGHT = " />"
 
+    EQUALS_QUOTE = '="'
+    QUOTE = '"'
+
     STANDARD_ELEMENTS = %w[
       a
       abbr

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -23,6 +23,26 @@ RSpec.describe Phlex::Component do
     end
   end
 
+  describe "with unique attributes" do
+    let :component do
+      Class.new Phlex::Component do
+        def template
+          div class: SecureRandom.hex
+        end
+      end
+    end
+
+    it "doesn't leak memory" do
+      component.new.call
+
+      report = MemoryProfiler.report do
+        10.times { component.new.call }
+      end
+
+      expect(report.total_retained).to eq(0)
+    end
+  end
+
   describe "when subclassing another component" do
     let(:component) { Class.new CardComponent }
 


### PR DESCRIPTION
11.8% performance improvement on our benchmark.

Before:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    35.000  i/100ms
Calculating -------------------------------------
                Page    355.176  (± 0.8%) i/s -      1.785k in   5.025994s
```

After:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    39.000  i/100ms
Calculating -------------------------------------
                Page    397.184  (± 0.3%) i/s -      1.989k in   5.007804s
```