### PR TITLE
Improve text content argument handling

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -10,7 +10,9 @@ module Phlex
           block = Block.new(self, &block)
         end
 
-        if !block_given? && args[0] && !method(__method__).super_method.parameters.to_h[:req]
+        super_method_params = method(__method__).super_method.parameters.to_h
+
+        if !block_given? && args[0] && !super_method_params[:req] && !super_method_params[:opt]
           content = args.delete_at(0)
           block = Block.new(self) { text content }
         end

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -27,11 +27,7 @@ module Phlex
         block = Block.new(self, &block)
       end
 
-      if args.one? && !block_given?
-        component.new(**kwargs) { text(args.first) }.call(@_target)
-      else
-        component.new(*args, **kwargs, &block).call(@_target)
-      end
+      component.new(*args, **kwargs, &block).call(@_target)
     end
 
     def _template_tag(*args, **kwargs, &)


### PR DESCRIPTION
Check if your initialiser handles positional arguments before assuming the first positional argument should be coerced into a block of text content.