### PR TITLE
Remove implicit content as positional argument

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -27,11 +27,7 @@ module Phlex
         block = Block.new(self, &block)
       end
 
-      if args.one? && !block_given?
-        component.new(**kwargs) { text(args.first) }.call(@_target)
-      else
-        component.new(*args, **kwargs, &block).call(@_target)
-      end
+      component.new(*args, **kwargs, &block).call(@_target)
     end
 
     def _template_tag(*args, **kwargs, &)

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -377,20 +377,6 @@ RSpec.describe Phlex::Component do
     end
   end
 
-  describe "with a positional argument" do
-    let(:component) do
-      Class.new Phlex::Component do
-        def template
-          component CardComponent, "Hello World!"
-        end
-      end
-    end
-
-    it "produces the correct markup" do
-      expect(output).to eq %{<article class="p-5 rounded drop-shadow">Hello World!</article>}
-    end
-  end
-
   describe "#format" do
     it "returns :html" do
       expect(example.format).to eq :html


### PR DESCRIPTION
I’m removing implicit content as positional arguments because they stop you from being able to define components that accept positional arguments. I attempted to get around this in #87.