### PR TITLE
Remove template override

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -14,21 +14,6 @@ module Phlex
 
         super(*args, **kwargs)
       end
-
-      def template(...)
-        called_from = caller_locations(1,1)[0].label.to_sym
-
-        # If we're rendering a template and not being called from
-        # another override in the ancestry, we render the template tag.
-
-        if @_rendering && (called_from != __method__)
-          _template_tag(...)
-        else
-          @_rendering = true
-          super
-          @_rendering = false
-        end
-      end
     end
 
     class << self

--- a/lib/phlex/rails/renderable.rb
+++ b/lib/phlex/rails/renderable.rb
@@ -7,11 +7,7 @@ module Phlex
 
     module Renderable
       def render(...)
-        if @_rendering
-          @_target << VIEW_CONTEXT.render(...)
-        else
-          call.html_safe
-        end
+        @_target << VIEW_CONTEXT.render(...)
       end
 
       def render_in(context, &)
@@ -21,7 +17,7 @@ module Phlex
           @_content = Phlex::Block.new(self) { @_target << content }
         end
 
-        render
+        call.html_safe
       end
 
       def format

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -324,24 +324,6 @@ RSpec.describe Phlex::Component do
       end
     end
 
-    describe "with a template tag" do
-      let :component do
-        Class.new Phlex::Component do
-          def template
-            div do
-              h1 "A"
-              template "B"
-              h2 "C"
-            end
-          end
-        end
-      end
-
-      it "produces the correct markup" do
-        expect(output).to eq "<div><h1>A</h1><template>B</template><h2>C</h2></div>"
-      end
-    end
-
     describe "with custom elements" do
       let :component do
         Class.new Phlex::Component do
@@ -405,49 +387,38 @@ RSpec.describe Phlex::Component do
   end
 
   describe "#render" do
-    describe "while not rendering" do
-      let(:output) { example.render }
+    describe "with locals" do
+      let(:component) do
+        Class.new Phlex::Component do
+          def template
+            component CardComponent do
+              render "shared/content", name: "Alexandre"
+            end
+          end
+        end
+      end
 
-      it "renders the component to an html_safe string" do
-        expect(output).to eq %{<h1>Hi</h1>}
-        expect(output).to be_html_safe
+      it "produces the correct markup" do
+        expect(output).to eq %{<article class="p-5 rounded drop-shadow">Welcome Alexandre!\n</article>}
       end
     end
 
-    describe "while rendering" do
-      describe "with locals" do
-        let(:component) do
-          Class.new Phlex::Component do
-            def template
-              component CardComponent do
-                render "shared/content", name: "Alexandre"
-              end
+    describe "with a model" do
+      let(:article) { Article.new(title: "Phlex documentation") }
+      let(:example) { component.new(article:) }
+
+      let(:component) do
+        Class.new Phlex::Component do
+          def template
+            component CardComponent do
+              render @article
             end
           end
-        end
-
-        it "produces the correct markup" do
-          expect(output).to eq %{<article class="p-5 rounded drop-shadow">Welcome Alexandre!\n</article>}
         end
       end
 
-      describe "with a model" do
-        let(:article) { Article.new(title: "Phlex documentation") }
-        let(:example) { component.new(article:) }
-
-        let(:component) do
-          Class.new Phlex::Component do
-            def template
-              component CardComponent do
-                render @article
-              end
-            end
-          end
-        end
-
-        it "produces the correct markup" do
-          expect(output).to eq %{<article class="p-5 rounded drop-shadow">Title: Phlex documentation\n</article>}
-        end
+      it "produces the correct markup" do
+        expect(output).to eq %{<article class="p-5 rounded drop-shadow">Title: Phlex documentation\n</article>}
       end
     end
   end


### PR DESCRIPTION
After the discussion with @eregon in #87, I think it'd be best to remove this override. I don’t think it’s worth the cost of performance and the extra complexity. Now, if you want a `<template>` tag, you need to use the `template_tag` method.

I also updated `Component#render` that was depending on this override unnecessarily. We actually don't need to respond to `render` to provide an HTML-safe render, as Rails will always call `render_in` if it's available. See #82 for more work on this where I’m trying to pass the view_context around so we can access the current request.

### Performance

Before
```
               phlex:     6919.5 i/s
      view_component:     5304.7 i/s - 1.30x  (± 0.00) slower
               cells:     3413.6 i/s - 2.03x  (± 0.00) slower
            partials:     2433.1 i/s - 2.84x  (± 0.00) slower
            dry_view:      337.7 i/s - 20.49x  (± 0.00) slower
```

After
```
               phlex:     8061.7 i/s
      view_component:     5290.0 i/s - 1.52x  (± 0.00) slower
               cells:     3442.0 i/s - 2.34x  (± 0.00) slower
            partials:     2428.9 i/s - 3.32x  (± 0.00) slower
            dry_view:      338.0 i/s - 23.85x  (± 0.00) slower
```