### PR TITLE
Detect unsafe attribute names

### DIFF
--- a/examples/page.rb
+++ b/examples/page.rb
@@ -7,7 +7,7 @@ module Example
         5.times do
           div do
             10.times do
-              a "Test", href: "something"
+              a "Test", href: "something", unique: SecureRandom.uuid
             end
           end
         end

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -7,6 +7,9 @@ loader = Zeitwerk::Loader.for_gem
 loader.setup
 
 module Phlex
+  Error = Module.new
+  ArgumentError = Class.new(ArgumentError) { include Error }
+
   extend self
 
   ATTRIBUTE_CACHE = {}

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -76,7 +76,17 @@ module Phlex
 
       buffer = first_render ? buffer = +"" : buffer = @_target
 
+      attributes.each_key do |key|
+        if key.match? /[<>&"']/
+          raise ArgumentError, <<~MESSAGE
+            Unsafe attribute name detected.
+            Attributes names shouldn't contain `<`, `>`, `&`, `"` or `'`.
+          MESSAGE
+        end
+      end
+
       attributes.transform_values! { CGI.escape_html(_1) }
+
       attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
 
       attributes.each do |k, v|

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -123,6 +123,26 @@ RSpec.describe Phlex::Component do
     end
   end
 
+  describe "with unsafe attributes" do
+    let :component do
+      Class.new Phlex::Component do
+        def template
+          article **attributes
+        end
+
+        def attributes
+          {
+            %{"><script type="text/javascript">alert(1);</script>} => "test"
+          }
+        end
+      end
+    end
+
+    it "escapes the content" do
+      expect { output }.to raise_error ArgumentError
+    end
+  end
+
   describe "with javascript link protocol in hypertext reference" do
     let :component do
       Class.new Phlex::Component do


### PR DESCRIPTION
Closes #92 

This didn't have any effect on our benchmarks because of the attribute caching so I added a unique attribute to the benchmark. With that, there appears to be a no significant performance impact when the attributes can't be cached. My benchmarks actually showed it was faster, but within error margins.

Before
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    40.000  i/100ms
Calculating -------------------------------------
                Page    400.399  (± 0.2%) i/s -      2.040k in   5.094980s
```

After
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    40.000  i/100ms
Calculating -------------------------------------
                Page    400.561  (± 0.2%) i/s -      2.040k in   5.092894s
```