### PR TITLE
Use fewer Phlex::Blocks

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -6,12 +6,7 @@ module Phlex
 
     module Overrides
       def initialize(*args, **kwargs, &block)
-        if block_given? && !block.binding.receiver.is_a?(Block)
-          block = Block.new(self, &block)
-        end
-
         @_content = block
-
         super(*args, **kwargs)
       end
     end

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -3,7 +3,7 @@
 module Phlex
   module Context
     def content(&)
-      yield(@_target) if block_given?
+      yield if block_given?
     end
 
     def text(content)
@@ -23,15 +23,11 @@ module Phlex
         raise ArgumentError, "#{component.name} isn't a Phlex::Component."
       end
 
-      if block_given? && !block.binding.receiver.is_a?(Block)
-        block = Block.new(self, &block)
+      if block_given? && !block.binding.receiver.is_a?(Phlex::Block)
+        block = Phlex::Block.new(self, &block)
       end
 
-      if args.one? && !block_given?
-        component.new(**kwargs) { text(args.first) }.call(@_target)
-      else
-        component.new(*args, **kwargs, &block).call(@_target)
-      end
+      component.new(*args, **kwargs, &block).call(@_target)
     end
 
     def _template_tag(*args, **kwargs, &)
@@ -47,16 +43,11 @@ module Phlex
       _attributes(kwargs) if kwargs.length > 0
       @_target << Tag::RIGHT
 
-
       if block_given?
-        if block.binding.receiver.is_a?(Block)
-          block.call(@_target)
-        else
-          Block.new(self, &block).call(@_target)
-        end
+        instance_exec(&block)
+      else
+        text content if content
       end
-
-      Block.new(self) { text content }.call(@_target) if content
 
       @_target << Tag::CLOSE_LEFT << name << Tag::RIGHT
     end

--- a/lib/phlex/rails/renderable.rb
+++ b/lib/phlex/rails/renderable.rb
@@ -14,7 +14,7 @@ module Phlex
         if block_given?
           content = nil
           context.with_output_buffer { content = yield }
-          @_content = Phlex::Block.new(self) { @_target << content }
+          @_content = -> { @_target << content }
         end
 
         call.html_safe

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -377,20 +377,6 @@ RSpec.describe Phlex::Component do
     end
   end
 
-  describe "with a positional argument" do
-    let(:component) do
-      Class.new Phlex::Component do
-        def template
-          component CardComponent, "Hello World!"
-        end
-      end
-    end
-
-    it "produces the correct markup" do
-      expect(output).to eq %{<article class="p-5 rounded drop-shadow">Hello World!</article>}
-    end
-  end
-
   describe "#format" do
     it "returns :html" do
       expect(example.format).to eq :html


### PR DESCRIPTION
I realised we don't need to use so many `Phlex::Blocks`. An 86% performance improvement.

Before:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    40.000  i/100ms
Calculating -------------------------------------
                Page    398.825  (± 0.5%) i/s -      2.000k in   5.014892s
```

```
               phlex:     8095.3 i/s
      view_component:     5362.8 i/s - 1.51x  (± 0.00) slower
               cells:     3458.0 i/s - 2.34x  (± 0.00) slower
            partials:     2481.5 i/s - 3.26x  (± 0.00) slower
            dry_view:      342.2 i/s - 23.66x  (± 0.00) slower
```


After:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    74.000  i/100ms
Calculating -------------------------------------
                Page    742.816  (± 0.1%) i/s -      3.774k in   5.080680s
```

```
               phlex:    10571.1 i/s
      view_component:     5395.3 i/s - 1.96x  (± 0.00) slower
               cells:     3491.6 i/s - 3.03x  (± 0.00) slower
            partials:     2501.6 i/s - 4.23x  (± 0.00) slower
            dry_view:      344.9 i/s - 30.65x  (± 0.00) slower
```
