### PR TITLE
Pass anonymous block to call when possible

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -38,12 +38,13 @@ module Phlex
       attributes.each { |k, v| instance_variable_set("@#{k}", v) }
     end
 
-    def call(buffer = +"")
+    def call(buffer = +"", &)
       raise "The same component instance shouldn't be rendered twice" if @_rendered
       @_rendered = true
-
       @_target = buffer
-      template(&@_content)
+
+      block_given? ? template(&) : template(&@_content)
+
       self.class.rendered_at_least_once ||= true
       buffer
     end

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -27,7 +27,7 @@ module Phlex
         block = Phlex::Block.new(self, &block)
       end
 
-      component.new(*args, **kwargs, &block).call(@_target)
+      component.new(*args, **kwargs).call(@_target, &block)
     end
 
     def _template_tag(*args, **kwargs, &)

--- a/lib/phlex/rails/renderable.rb
+++ b/lib/phlex/rails/renderable.rb
@@ -14,10 +14,13 @@ module Phlex
         if block_given?
           content = nil
           context.with_output_buffer { content = yield }
-          @_content = -> { @_target << content }
         end
 
-        call.html_safe
+        if content
+          call { @_target << content }.html_safe
+        else
+          call.html_safe
+        end
       end
 
       def format


### PR DESCRIPTION
There's a performance optimisation we can do when we want to call a component immediately. Instead of passing the content block to the initialiser, we pass it to call. Call can handle it as an anonymous block, saving time.

Before
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    74.000  i/100ms
Calculating -------------------------------------
                Page    739.993  (± 0.7%) i/s -     14.800k in  20.001074s
```

After
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    74.000  i/100ms
Calculating -------------------------------------
                Page    742.746  (± 0.5%) i/s -     14.874k in  20.026150s
```