### PR TITLE
Shortcut for component text content

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -3,7 +3,11 @@
 module Phlex
   module Context
     def content(&)
-      yield if block_given?
+      original_bytesize = @_target.size
+      output = yield if block_given?
+      unchanged = (original_bytesize == @_target.size)
+
+      text(output) if unchanged && output.is_a?(String)
     end
 
     def text(content)
@@ -44,7 +48,7 @@ module Phlex
       @_target << Tag::RIGHT
 
       if block_given?
-        instance_exec(&block)
+        content(&block)
       else
         text content if content
       end

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -65,6 +65,20 @@ RSpec.describe Phlex::Component do
     end
   end
 
+  describe "with text content" do
+    let(:component) do
+      Class.new Phlex::Component do
+        def template
+          component(CardComponent) { "Hello World!" }
+        end
+      end
+    end
+
+    it "produces the correct markup" do
+      expect(output).to eq %{<article class="p-5 rounded drop-shadow">Hello World!</article>}
+    end
+  end
+
   describe "with raw content" do
     let :component do
       Class.new Phlex::Component do


### PR DESCRIPTION
With this change, we can pass text content as a string wrapped in a block.

To support this, we need to detect whether yielding the block modifies the buffer. If there is no modification and the return value is a string, we can treat it as text. This provides a nice clean way to add text to a component without having to do circus stunts in an initialiser override. (See #87)

```ruby
component(MyComponent) { "Hello World" }
```

### Performance

This is quite expensive, a ~3% performance hit. But I think it might be worth it for the improved developer experience. Also, I think we can optimise this away with a compiler.

Before
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    74.000  i/100ms
Calculating -------------------------------------
                Page    745.695  (± 0.1%) i/s -      3.774k in   5.061059s
```

After
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    72.000  i/100ms
Calculating -------------------------------------
                Page    722.157  (± 0.4%) i/s -      3.672k in   5.084834s
```