### PR TITLE
Capture component parent

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -5,9 +5,10 @@ module Phlex
     include Context, Renderable
 
     module Overrides
-      def initialize(*args, _view_context: nil, **kwargs, &block)
-        @_content = block
+      def initialize(*args, _view_context: nil, _parent: nil, **kwargs, &block)
         @_view_context = _view_context
+        @_parent = _parent
+        @_content = block
         super(*args, **kwargs)
       end
     end

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -31,7 +31,7 @@ module Phlex
         block = Phlex::Block.new(self, &block)
       end
 
-      component.new(*args, _view_context: @_view_context, **kwargs).call(@_target, &block)
+      component.new(*args, _view_context: @_view_context, _parent: self, **kwargs).call(@_target, &block)
     end
 
     def _template_tag(*args, **kwargs, &)


### PR DESCRIPTION
When working with DSLs, it can be useful to be able to execute a block against the parent component.