### PR TITLE
Boolean attributes

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -80,12 +80,21 @@ module Phlex
         end
       end
 
-      attributes.transform_values! { CGI.escape_html(_1) }
+      attributes.transform_values! do |value|
+        next value if (value == true || value == false)
+        CGI.escape_html(value)
+      end
 
       attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
 
       attributes.each do |k, v|
-        buffer << Tag::SPACE << k.name << Tag::EQUALS_QUOTE << v << Tag::QUOTE
+        next unless v
+
+        if v == true
+          buffer << Tag::SPACE << k.name
+        else
+          buffer << Tag::SPACE << k.name << Tag::EQUALS_QUOTE << v << Tag::QUOTE
+        end
       end
 
       if first_render

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          h1 "Hello", id: "foo"
+          h1 "Hello", id: "foo", disabled: true, visible: false
         end
       end
     end
@@ -196,7 +196,7 @@ RSpec.describe Phlex::Component do
     end
 
     it "produces the correct markup" do
-      expect(output).to eq %{<h1 id="foo">Hello</h1>}
+      expect(output).to eq %{<h1 id="foo" disabled>Hello</h1>}
     end
   end
 


### PR DESCRIPTION
Support boolean HTML attributes, e.g. `input type: "radio", checked: true`.