### PR TITLE
Add pointer cursor to tab headers to make them look clickable

### DIFF
--- a/docs/components/tabs/tab.rb
+++ b/docs/components/tabs/tab.rb
@@ -8,7 +8,7 @@ module Components
       def template
         input class: "opacity-0 fixed peer", type: "radio", name: @_parent.object_id, id: object_id, checked: @checked
 
-        label @name, for: object_id, class: "order-1 py-2 px-5 bg-white text-sm border border-b-0 border-l-0 font-medium first-of-type:border-l first-of-type:rounded-tl last-of-type:rounded-tr before:absolute before:w-full before:ring before:h-full before:left-0 before:top-0 before:hidden before:rounded peer-focus:before:block"
+        label @name, for: object_id, class: "order-1 py-2 px-5 bg-white text-sm border border-b-0 border-l-0 font-medium first-of-type:border-l first-of-type:rounded-tl last-of-type:rounded-tr before:absolute before:w-full before:ring before:h-full before:left-0 before:top-0 before:hidden before:rounded peer-focus:before:block cursor-pointer"
 
         div class: "tab hidden order-2 w-full border rounded-b rounded-tr overflow-hidden", &@content
       end


### PR DESCRIPTION
Was having a look at the docs and noticed that the tab headers didn't have the pointer cursor that makes them look clickable like any other link.

Small fix for that in this PR as I wanted to see if I can contribute a bit to this project :)

I think the tabs are still a bit weird, as they get focus when you click one and you have to click again to unfocus before you can click something else, but not sure how to fix that properly without rewriting the whole component.