### PR TITLE
Override `.new` instead of `#initialize`

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -4,17 +4,20 @@ module Phlex
   class Component
     include Context, Renderable
 
-    module Overrides
-      def initialize(*args, _view_context: nil, _parent: nil, **kwargs, &block)
-        @_view_context = _view_context
-        @_parent = _parent
-        @_content = block
-        super(*args, **kwargs)
-      end
-    end
-
     class << self
       attr_accessor :rendered_at_least_once
+
+      def new(*args, _view_context: nil, _parent: nil, **kwargs, &block)
+        component = super(*args, **kwargs)
+
+        component.instance_exec do
+          @_view_context = _view_context
+          @_parent = _parent
+          @_content = block
+        end
+
+        component
+      end
 
       def register_element(*tag_names)
         tag_names.each do |tag_name|
@@ -28,11 +31,6 @@ module Phlex
             end
           RUBY
         end
-      end
-
-      def inherited(child)
-        child.prepend(Overrides)
-        super
       end
     end
 


### PR DESCRIPTION
If we override `.new`, we don't need to prepend a module to override `#initialize`. This seems to be faster and it also keeps the ancestry nice and clean, especially when subclassing a component, since every time a component is subclassed, a new override would have been prepended on it.

Before:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    70.000  i/100ms
Calculating -------------------------------------
                Page    696.288  (± 1.0%) i/s -      3.500k in   5.027149s
```

After:
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    71.000  i/100ms
Calculating -------------------------------------
                Page    701.157  (± 1.0%) i/s -      3.550k in   5.063536s
```