### PR TITLE
Yield self pattern

### DIFF
--- a/docs/components/example.rb
+++ b/docs/components/example.rb
@@ -1,63 +1,30 @@
 module Components
   class Example < Phlex::Component
-    class DSL
-      def initialize
-        @tabs = {}
-      end
-
-      def tab(name, code)
-        @tabs[name] = code
-      end
-
-      def execute(value)
-        @execute = value
-      end
-    end
-
     def initialize
-      @dsl = DSL.new
+      @sandbox = Module.new
     end
 
     def template(&)
-      yield(@dsl)
-
       component Tabs do |t|
-        tabs.each do |name, code|
-          t.tab name do
-            component CodeBlock, code, syntax: :ruby
-          end
-        end
-
-        pretty_output.tap do |pretty_output|
-          t.tab "HTML Output" do
-            component CodeBlock, pretty_output, syntax: :html
-          end
-        end
+        @t = t
+        yield self
       end
     end
 
-    private
-
-    def pretty_output
-      HtmlBeautifier.beautify(output, new_lines: true)
-    end
-
-    def output
-      return @output if defined? @output
-
-      tabs.each_value do |code|
-        sandbox.instance_eval(code)
+    def tab(name, code)
+      @t.tab(name) do
+        component CodeBlock, code, syntax: :ruby
       end
 
-      @output = sandbox.instance_eval(@dsl.instance_variable_get(:@execute))
+      @sandbox.instance_eval(code)
     end
 
-    def tabs
-      @dsl.instance_variable_get(:@tabs)
-    end
+    def execute(code)
+      output = @sandbox.instance_eval(code)
 
-    def sandbox
-      @sandbox ||= Module.new
+      @t.tab("HTML Output") do
+        component CodeBlock, HtmlBeautifier.beautify(output), syntax: :html
+      end
     end
   end
 end

--- a/docs/components/tabs.rb
+++ b/docs/components/tabs.rb
@@ -1,36 +1,24 @@
 module Components
   class Tabs < Phlex::Component
-    class DSL
-      def initialize
-        @tabs = {}.compare_by_identity
-      end
-
-      def tab(name, &block)
-        @tabs[name] = block
-      end
-    end
-
     def initialize
-      @dsl = DSL.new
+      @index = 1
     end
 
     def template(&)
-      yield(@dsl)
-
       div class: "tabs flex flex-wrap relative my-5" do
-        number = 1
-
-        tabs.each do |name, content|
-          component Tab, name:, content:, checked: (number == 1)
-          number += 1
-        end
+        yield(self)
       end
+    end
+
+    def tab(name, &)
+      component Tab, name:, content: phlex_block(&), checked: first?
+      @index += 1
     end
 
     private
 
-    def tabs
-      @dsl.instance_variable_get(:@tabs)
+    def first?
+      @index == 1
     end
   end
 end

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -48,5 +48,10 @@ module Phlex
       self.class.rendered_at_least_once ||= true
       buffer
     end
+
+    def phlex_block(&block)
+      return block if block.binding.receiver.is_a?(Phlex::Block)
+      Phlex::Block.new(@_parent, &block)
+    end
   end
 end


### PR DESCRIPTION
I spent a while working on an abstraction for component DSLs in #106 and realised it was much simpler to just `yield(self)` with some extra public methods. I’ll spend some time documenting this pattern in our docs at some point. I think it’s incredibly powerful.