### PR TITLE
Dasherize HTML tag attributes

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -71,29 +71,22 @@ module Phlex
 
       buffer = first_render ? buffer = +"" : buffer = @_target
 
-      attributes.each_key do |key|
-        if key.match? /[<>&"']/
+      attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "") if attributes[:href]
+
+      attributes.each do |k, v|
+        next unless v
+
+        if k.match? /[<>&"']/
           raise ArgumentError, <<~MESSAGE
             Unsafe attribute name detected.
             Attributes names shouldn't contain `<`, `>`, `&`, `"` or `'`.
           MESSAGE
         end
-      end
-
-      attributes.transform_values! do |value|
-        next value if (value == true || value == false)
-        CGI.escape_html(value.to_s)
-      end
-
-      attributes[:href].sub!(/^\s*(javascript:)+/, "") if attributes[:href]
-
-      attributes.each do |k, v|
-        next unless v
 
         if v == true
-          buffer << Tag::SPACE << k.name
+          buffer << Tag::SPACE << k.name.gsub(Tag::UNDERSCORE, Tag::DASH)
         else
-          buffer << Tag::SPACE << k.name << Tag::EQUALS_QUOTE << v << Tag::QUOTE
+          buffer << Tag::SPACE << k.name.gsub(Tag::UNDERSCORE, Tag::DASH) << Tag::EQUALS_QUOTE << CGI.escape_html(v.to_s) << Tag::QUOTE
         end
       end
 

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          h1 "Hello", id: "foo", disabled: true, visible: false
+          h1 "Hello", id: "foo", disabled: true, visible: false, aria_hidden: "true"
         end
       end
     end
@@ -196,7 +196,7 @@ RSpec.describe Phlex::Component do
     end
 
     it "produces the correct markup" do
-      expect(output).to eq %{<h1 id="foo" disabled>Hello</h1>}
+      expect(output).to eq %{<h1 id="foo" disabled aria-hidden="true">Hello</h1>}
     end
   end
 


### PR DESCRIPTION
I think it makes sense to automatically dasherize HTML tag attributes, since this is the norm and you can't easily use dashes in symbols.