### PR TITLE
Build docs as a CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,6 @@ jobs:
 
       - name: Run specs
         run: bundle exec rspec
+
+      - name: Build docs
+        run: bundle exec docs/build.rb


### PR DESCRIPTION
CI should fail if building the docs raises.