### PR TITLE
Support Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1']
+        ruby-version: ['2.7', '3.0', '3.1']
 
     steps:
       - uses: actions/checkout@v3

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -7,6 +7,16 @@ loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/generators")
 loader.setup
 
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
+  unless Symbol.instance_methods.include?(:name)
+    class Symbol
+      def name
+        to_s.freeze
+      end
+    end
+  end
+end
+
 module Phlex
   Error = Module.new
   ArgumentError = Class.new(ArgumentError) { include Error }

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -14,6 +14,7 @@ module Phlex
           @_view_context = _view_context
           @_parent = _parent
           @_content = block
+          @_rendered = false
         end
 
         component

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -76,7 +76,7 @@ module Phlex
       attributes.each do |k, v|
         next unless v
 
-        if k.match? /[<>&"']/
+        if k.match?(/[<>&"']/)
           raise ArgumentError, <<~MESSAGE
             Unsafe attribute name detected.
             Attributes names shouldn't contain `<`, `>`, `&`, `"` or `'`.

--- a/phlex.gemspec
+++ b/phlex.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Better view components"
   spec.homepage = "https://github.com/joeldrapper/phlex"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/joeldrapper/phlex"

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          article **attributes
+          article(**attributes)
         end
 
         def attributes


### PR DESCRIPTION
Looks like we can support Ruby 2.7 with just one patch to Symbol to make it alias `name` to `to_s.freeze`. Using `name` instead of `to_s` is faster in newer Rubies.

With these changes, specs pass in Ruby 2.7.6 without any warnings.