### PR TITLE
Replace `component` with a `render` fast path

### DIFF
--- a/docs/components/example.rb
+++ b/docs/components/example.rb
@@ -5,7 +5,7 @@ module Components
     end
 
     def template(&)
-      component Tabs do |t|
+      render Tabs.new do |t|
         @t = t
         yield self
       end
@@ -13,7 +13,7 @@ module Components
 
     def tab(name, code)
       @t.tab(name) do
-        component CodeBlock, code, syntax: :ruby
+        render CodeBlock.new(code, syntax: :ruby)
       end
 
       @sandbox.instance_eval(code)
@@ -23,7 +23,7 @@ module Components
       output = @sandbox.instance_eval(code)
 
       @t.tab("HTML Output") do
-        component CodeBlock, HtmlBeautifier.beautify(output), syntax: :html
+        render CodeBlock.new(HtmlBeautifier.beautify(output), syntax: :html)
       end
     end
   end

--- a/docs/components/tabs.rb
+++ b/docs/components/tabs.rb
@@ -11,7 +11,7 @@ module Components
     end
 
     def tab(name, &)
-      component Tab, name:, checked: first?, &phlex_block(&)
+      render Tab.new(name:, checked: first?, &phlex_block(&))
       @index += 1
     end
 

--- a/docs/pages/components.rb
+++ b/docs/pages/components.rb
@@ -1,8 +1,8 @@
 module Pages
   class Components < ApplicationPage
     def template
-      component Layout, title: "Components in Phlex" do
-        component Markdown, <<~MD
+      render Layout.new(title: "Components in Phlex") do
+        render Markdown.new(<<~MD)
           # Components
 
           ## Yielding content
@@ -10,7 +10,7 @@ module Pages
           Your components can accept content as a block passed to the template method. You can capture the content block and pass it to the `content` method to yield it.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "card_component.rb", <<~RUBY
             class CardComponent < Phlex::Component
               def template(&)
@@ -25,13 +25,13 @@ module Pages
           e.execute "CardComponent.new.call { 'Your content here.\n' }"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           ## Delegating content
 
           Alternatively, you can pass the content down as an argument to another component or tag.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "card_component.rb", <<~RUBY
             class CardComponent < Phlex::Component
               def template(&)
@@ -43,17 +43,17 @@ module Pages
           e.execute "CardComponent.new.call { 'Your content here.' }"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           ## Nested components
 
           Components can render other components and optionally pass them content as a block.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "example_component.rb", <<~RUBY
             class ExampleComponent < Phlex::Component
               def template
-                component CardComponent do
+                render CardComponent.new do
                   h1 "Hello"
                 end
               end
@@ -71,15 +71,15 @@ module Pages
           e.execute "ExampleComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           If the block just wraps a string, the string is treated as _text content_.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "example_component.rb", <<~RUBY
             class ExampleComponent < Phlex::Component
               def template
-                component(CardComponent) { "Hi" }
+                render(CardComponent.new) { "Hi" }
               end
             end
           RUBY
@@ -95,13 +95,13 @@ module Pages
           e.execute "ExampleComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           ## Component attributes
 
           Besides content, components can define attributes in an initializer, which can then be rendered in the template.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "hello_component.rb", <<~RUBY
             class HelloComponent < Phlex::Component
               def initialize(name:)
@@ -117,7 +117,7 @@ module Pages
           e.tab "example_component.rb", <<~RUBY
             class ExampleComponent < Phlex::Component
               def template
-                component HelloComponent, name: "Joel"
+                render HelloComponent.new(name: "Joel")
               end
             end
           RUBY
@@ -125,11 +125,11 @@ module Pages
           e.execute "ExampleComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           The default initializer in `Phlex::Component` sets each given keyword argument to an instance variable, so the above could be re-written to call `super` instead.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "hello_component.rb", <<~RUBY
             class HelloComponent < Phlex::Component
               def initialize(name:)
@@ -145,7 +145,7 @@ module Pages
           e.tab "example_component.rb", <<~RUBY
             class ExampleComponent < Phlex::Component
               def template
-                component HelloComponent, name: "Joel"
+                render HelloComponent.new(name: "Joel")
               end
             end
           RUBY
@@ -153,7 +153,7 @@ module Pages
           e.execute "ExampleComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           It’s usually a good idea to use instance variables directly rather than creating accessor methods for them. Otherwise it’s easy to run into naming conflicts. For example, your layout component might have the attribute `title`, to render into a `<title>` element in the document head. If you define `attr_accessor :title`, that would overwrite the `title` method for creating `<title>` elements.
 
           ## Calculations with methods
@@ -161,7 +161,7 @@ module Pages
           Components are just Ruby classes, so you can perform calculations on component attributes by defining your own methods.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "status_component.rb", <<~RUBY
             class StatusComponent < Phlex::Component
               def initialize(status:)
@@ -188,7 +188,7 @@ module Pages
           e.tab "example_component.rb", <<~RUBY
             class ExampleComponent < Phlex::Component
               def template
-                component StatusComponent, status: :success
+                render StatusComponent.new(status: :success)
               end
             end
           RUBY

--- a/docs/pages/index.rb
+++ b/docs/pages/index.rb
@@ -1,8 +1,8 @@
 module Pages
   class Index < ApplicationPage
     def template
-      component Layout, title: "Introduction to Phlex" do
-        component Markdown, <<~MD
+      render Layout.new(title: "Introduction to Phlex") do
+        render Markdown.new(<<~MD)
           # Introduction
 
           Phlex is a framework for building fast, reusable, testable view components in pure Ruby.

--- a/docs/pages/templates.rb
+++ b/docs/pages/templates.rb
@@ -1,8 +1,8 @@
 module Pages
   class Templates < ApplicationPage
     def template
-      component Layout, title: "Templates in Phlex" do
-        component Markdown, <<~MD
+      render Layout.new(title: "Templates in Phlex") do
+        render Markdown.new(<<~MD)
           # Templates
 
           Rather than use another langauge like ERB, HAML or Slim, Phlex provides a Ruby DSL for defining HTML templates.
@@ -12,7 +12,7 @@ module Pages
           The first argument to an HTML element method is the _text content_ for that element. For example, here’s a component with an `<h1>` element that says “Hello World!”
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "heading_component.rb", <<~RUBY
             class HeadingComponent < Phlex::Component
               def template
@@ -24,7 +24,7 @@ module Pages
           e.execute "HeadingComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           The text content is always HTML-escaped, so it’s safe to use with user input.
 
           ## Attributes
@@ -32,7 +32,7 @@ module Pages
           You can add attributes to HTML elements by passing keyword arguments to the tag method. Underscores (`_`) in attribute names are automatically converted to dashes (`-`).
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "heading_component.rb", <<~RUBY
             class HeadingComponent < Phlex::Component
               def template
@@ -46,11 +46,11 @@ module Pages
           e.execute "HeadingComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           You can also use *boolean* attributes. When set to `true`, the attribute will be rendered without a value, when _falsy_, the attribute isn’t rendered at all.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "example_component.rb", <<~RUBY
             class ExampleComponent < Phlex::Component
               def template
@@ -63,13 +63,13 @@ module Pages
           e.execute "ExampleComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           ## Nesting
 
           Pass a block to an element method to nest other elements inside it.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "nav_component.rb", <<~RUBY
             class NavComponent < Phlex::Component
               def template
@@ -87,13 +87,13 @@ module Pages
           e.execute "NavComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           ## Stand-alone text
 
           You can also output text without wrapping it in an element by using the `text` method. All text content is HTML-escaped, so it’s safe to use with user input.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "heading_component.rb", <<~RUBY
             class HeadingComponent < Phlex::Component
               def template
@@ -105,13 +105,13 @@ module Pages
           e.execute "HeadingComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           ## Whitespace
 
           While the examples on this page have been formatted for readability, there is usually no whitespace between HTML tags. If you need to add some whitespace, you can use the `whitespace` method. This is useful for adding space between _inline_ elements to allow them to wrap.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "example_component.rb", <<~RUBY
             class LinksComponent < Phlex::Component
               def template
@@ -127,13 +127,13 @@ module Pages
           e.execute "LinksComponent.new.call"
         end
 
-        component Markdown, <<~MD
+        render Markdown.new(<<~MD)
           ## The template element
 
           Because the `template` method is used to define the component template itself, you need to use the method `template_tag` if you want to to render an HTML `<template>` tag.
         MD
 
-        component Example do |e|
+        render Example.new do |e|
           e.tab "example_component.rb", <<~RUBY
             class ExampleComponent < Phlex::Component
               def template

--- a/examples/page.rb
+++ b/examples/page.rb
@@ -1,7 +1,7 @@
 module Example
   class Page < Phlex::Component
     def template
-      component LayoutComponent do
+      render LayoutComponent.new do
         h1 "Hi"
 
         5.times do

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -7,12 +7,10 @@ module Phlex
     class << self
       attr_accessor :rendered_at_least_once
 
-      def new(*args, _view_context: nil, _parent: nil, **kwargs, &block)
+      def new(*args, **kwargs, &block)
         component = super(*args, **kwargs)
 
         component.instance_exec do
-          @_view_context = _view_context
-          @_parent = _parent
           @_content = block
           @_rendered = false
         end
@@ -39,10 +37,12 @@ module Phlex
       attributes.each { |k, v| instance_variable_set("@#{k}", v) }
     end
 
-    def call(buffer = +"", &block)
+    def call(buffer = +"", view_context: nil, parent: nil, &block)
       raise "The same component instance shouldn't be rendered twice" if @_rendered
       @_rendered = true
       @_target = buffer
+      @_view_context = view_context
+      @_parent = parent
 
       block_given? ? template(&block) : template(&@_content)
 

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -22,18 +22,6 @@ module Phlex
       @_target << content
     end
 
-    def component(component, *args, **kwargs, &block)
-      unless component < Component
-        raise ArgumentError, "#{component.name} isn't a Phlex::Component."
-      end
-
-      if block_given? && !block.binding.receiver.is_a?(Phlex::Block)
-        block = Phlex::Block.new(self, &block)
-      end
-
-      component.new(*args, _view_context: @_view_context, _parent: self, **kwargs).call(@_target, &block)
-    end
-
     def template_tag(*args, **kwargs, &block)
       _standard_element(*args, _name: "template", **kwargs, &block)
     end

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Phlex::Component do
     let(:component) do
       Class.new Phlex::Component do
         def template
-          component(CardComponent) { "Hello World!" }
+          render(CardComponent.new) { "Hello World!" }
         end
       end
     end
@@ -320,7 +320,7 @@ RSpec.describe Phlex::Component do
 
           def template
             main {
-              component(CardComponent) {
+              render(CardComponent.new) {
                 h1 @status
                 h2 status_emoji
               }
@@ -348,20 +348,6 @@ RSpec.describe Phlex::Component do
 
       it "produces the correct markup" do
         expect(output).to eq %{<main><article class="p-5 rounded drop-shadow"><h1>done</h1><h2>✅</h2></article></main>}
-      end
-    end
-
-    describe "that isn't a component" do
-      let :component do
-        Class.new Phlex::Component do
-          def template
-            component Set
-          end
-        end
-      end
-
-      it "raises an ArgumentError" do
-        expect { output }.to raise_error(ArgumentError, "Set isn't a Phlex::Component.")
       end
     end
 
@@ -422,7 +408,7 @@ RSpec.describe Phlex::Component do
       let(:component) do
         Class.new Phlex::Component do
           def template
-            component CardComponent do
+            render CardComponent.new do
               render "shared/content", name: "Alexandre"
             end
           end
@@ -444,8 +430,8 @@ RSpec.describe Phlex::Component do
       let(:component) do
         Class.new Phlex::Component do
           def template
-            component CardComponent do
-              component ArticleComponent, article: @article
+            render CardComponent.new do
+              render ArticleComponent.new(article: @article)
             end
           end
         end


### PR DESCRIPTION
I’ve removed the `component` method and updated `render` with a fast path to render Phlex component instances.

Before this change, you could render components like this:

```ruby
class ExampleComponent < Phlex::Component
  def template
    component CardComponent, title: "Hello" do
      p "Hello world!"
    end
  end
end
```

Now, you have to render them like this:

```ruby
class ExampleComponent < Phlex::Component
  def template
    render CardComponent.new(title: "Hello") do
      p "Hello world!"
    end
  end
end
```

### Why

1. It’s faster. Don't ask me why, I don’t have a clue. 🙃
2. It’s clearer how `.new` maps to `initialize` — the first argument is the first argument, etc. With `component`, you had to remember the first argument is the component class, then the next arguments are passed to its initialiser.
3. It’s more consistent with ViewComponent. This is how people are used to rendering subcomponents.
4. It’s more consistent with other renderables, such as partials.

### Benchmarks

Using `component`:
```
Comparison:
               phlex:     9644.5 i/s
      view_component:     5444.6 i/s - 1.77x  (± 0.00) slower
               cells:     3482.0 i/s - 2.77x  (± 0.00) slower
            partials:     2546.8 i/s - 3.79x  (± 0.00) slower
            dry_view:      352.5 i/s - 27.36x  (± 0.00) slower
```

Using `render`:
```
Comparison:
               phlex:    11100.0 i/s
      view_component:     5418.5 i/s - 2.05x  (± 0.00) slower
               cells:     3499.0 i/s - 3.17x  (± 0.00) slower
            partials:     2506.0 i/s - 4.43x  (± 0.00) slower
            dry_view:      352.0 i/s - 31.53x  (± 0.00) slower
```