### PR TITLE
Allow unsafe attributes in a `without_attribute_safety` block

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -13,6 +13,7 @@ module Phlex
         component.instance_exec do
           @_content = block
           @_rendered = false
+          @_allow_unsafe_attributes = false
         end
 
         component


### PR DESCRIPTION
I don’t know if we should ship this feature without a strong use-case for it. You shouldn’t ever need to use HTML event attributes or `javascript:` links and these should ideally be blocked in your CSP anyway.