### PR TITLE
Add missing `link`, `style`, `meta` elements

### DIFF
--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -67,10 +67,12 @@ module Phlex
       label
       legend
       li
+      link
       main
       map
       mark
       menuitem
+      meta
       meter
       nav
       noscript
@@ -96,6 +98,7 @@ module Phlex
       small
       span
       strong
+      style
       sub
       summary
       sup


### PR DESCRIPTION
Very useful in `<head>` scenarios and possibly other places (`link` and `style` can go in `body` as well).

Q: any tests needed to update?