### PR TITLE
All-caps tag methods

### DIFF
--- a/docs/components/callout.rb
+++ b/docs/components/callout.rb
@@ -1,7 +1,7 @@
 module Components
   class Callout < Phlex::Component
     def template(&)
-      div(class: "rounded bg-orange-50 text-sm p-5 border border-orange-100", &)
+      DIV(class: "rounded bg-orange-50 text-sm p-5 border border-orange-100", &)
     end
   end
 end

--- a/docs/components/code_block.rb
+++ b/docs/components/code_block.rb
@@ -8,7 +8,7 @@ module Components
     end
 
     def template
-      pre(class: "highlight p-5 whitespace-pre-wrap bg-stone-50") {
+      PRE(class: "highlight p-5 whitespace-pre-wrap bg-stone-50") {
         _raw FORMATTER.format(
           lexer.lex(@code)
         )

--- a/docs/components/heading.rb
+++ b/docs/components/heading.rb
@@ -1,7 +1,7 @@
 module Components
   class Heading < Phlex::Component
     def template(&)
-      h2(class: "text-xl font-bold mt-10 mb-5", &)
+      H2(class: "text-xl font-bold mt-10 mb-5", &)
     end
   end
 end

--- a/docs/components/layout.rb
+++ b/docs/components/layout.rb
@@ -9,32 +9,32 @@ module Components
     def template(&)
       doctype
 
-      html do
-        head do
-          meta charset: "utf-8"
-          title @title
-          link href: "/application.css", rel: "stylesheet"
-          style { _raw Rouge::Theme.find("github").render(scope: '.highlight') }
+      HTML do
+        HEAD do
+          META charset: "utf-8"
+          TITLE @title
+          LINK href: "/application.css", rel: "stylesheet"
+          STYLE { _raw Rouge::Theme.find("github").render(scope: '.highlight') }
         end
 
-        body class: "p-12" do
-          div class: "max-w-screen-lg mx-auto grid grid-cols-4 gap-10" do
-            header class: "col-span-1" do
-              a(href: "/", class: "block") { img src: "/assets/logo.png", width: "150" }
+        BODY class: "p-12" do
+          DIV class: "max-w-screen-lg mx-auto grid grid-cols-4 gap-10" do
+            HEADER class: "col-span-1" do
+              A(href: "/", class: "block") { IMG src: "/assets/logo.png", width: "150" }
 
-              nav do
-                ul do
-                  li { a "Introduction", href: "/" }
-                  li { a "Templates", href: "/templates" }
-                  li { a "Components", href: "/components" }
-                  li { a "Source code", href: "https://github.com/joeldrapper/phlex" }
+              NAV do
+                UL do
+                  LI { A "Introduction", href: "/" }
+                  LI { A "Templates", href: "/templates" }
+                  LI { A "Components", href: "/components" }
+                  LI { A "Source code", href: "https://github.com/joeldrapper/phlex" }
                 end
               end
             end
 
-            main(class: "col-span-3", &)
+            MAIN(class: "col-span-3", &)
 
-            footer class: "text-sm text-right col-span-4 py-10"
+            FOOTER class: "text-sm text-right col-span-4 py-10"
           end
         end
       end

--- a/docs/components/tabs.rb
+++ b/docs/components/tabs.rb
@@ -5,7 +5,7 @@ module Components
     end
 
     def template(&)
-      div class: "tabs flex flex-wrap relative my-5", role: "tablist" do
+      DIV class: "tabs flex flex-wrap relative my-5", role: "tablist" do
         yield(self)
       end
     end

--- a/docs/components/tabs/tab.rb
+++ b/docs/components/tabs/tab.rb
@@ -6,11 +6,11 @@ module Components
       end
 
       def template(&)
-        input class: "opacity-0 fixed peer", type: "radio", name: @_parent.unique_identifier, id: unique_identifier, checked: @checked
+        INPUT class: "opacity-0 fixed peer", type: "radio", name: @_parent.unique_identifier, id: unique_identifier, checked: @checked
 
-        label @name, id: "#{unique_identifier}-label", for: unique_identifier, role: "tab", aria_controls: "#{unique_identifier}-panel", class: "order-1 py-2 px-5 bg-white text-sm border border-b-0 border-l-0 font-medium first-of-type:border-l first-of-type:rounded-tl last-of-type:rounded-tr before:absolute before:w-full before:ring before:h-full before:left-0 before:top-0 before:hidden before:rounded peer-focus:before:block cursor-pointer"
+        LABEL @name, id: "#{unique_identifier}-label", for: unique_identifier, role: "tab", aria_controls: "#{unique_identifier}-panel", class: "order-1 py-2 px-5 bg-white text-sm border border-b-0 border-l-0 font-medium first-of-type:border-l first-of-type:rounded-tl last-of-type:rounded-tr before:absolute before:w-full before:ring before:h-full before:left-0 before:top-0 before:hidden before:rounded peer-focus:before:block cursor-pointer"
 
-        div id: "#{unique_identifier}-panel", role: "tabpanel", aria_labelledby: "#{unique_identifier}-label", class: "tab hidden order-2 w-full border rounded-b rounded-tr overflow-hidden", &
+        DIV id: "#{unique_identifier}-panel", role: "tabpanel", aria_labelledby: "#{unique_identifier}-label", class: "tab hidden order-2 w-full border rounded-b rounded-tr overflow-hidden", &
       end
 
       def unique_identifier

--- a/docs/components/title.rb
+++ b/docs/components/title.rb
@@ -1,7 +1,7 @@
 module Components
   class Title < Phlex::Component
     def template(&)
-      h1(class: "text-2xl font-bold my-5", &)
+      H1(class: "text-2xl font-bold my-5", &)
     end
   end
 end

--- a/docs/pages/components.rb
+++ b/docs/pages/components.rb
@@ -14,8 +14,8 @@ module Pages
           e.tab "card_component.rb", <<~RUBY
             class CardComponent < Phlex::Component
               def template(&)
-                article(class: "drop-shadow rounded p-5") {
-                  h1 "Amazing content!"
+                ARTICLE(class: "drop-shadow rounded p-5") {
+                  H1 "Amazing content!"
                   content(&)
                 }
               end
@@ -35,7 +35,7 @@ module Pages
           e.tab "card_component.rb", <<~RUBY
             class CardComponent < Phlex::Component
               def template(&)
-                article(class: "drop-shadow rounded p-5", &)
+                ARTICLE(class: "drop-shadow rounded p-5", &)
               end
             end
           RUBY
@@ -54,7 +54,7 @@ module Pages
             class ExampleComponent < Phlex::Component
               def template
                 render CardComponent.new do
-                  h1 "Hello"
+                  H1 "Hello"
                 end
               end
             end
@@ -63,7 +63,7 @@ module Pages
           e.tab "card_component.rb", <<~RUBY
             class CardComponent < Phlex::Component
               def template(&)
-                article(class: "drop-shadow rounded p-5", &)
+                ARTICLE(class: "drop-shadow rounded p-5", &)
               end
             end
           RUBY
@@ -87,7 +87,7 @@ module Pages
           e.tab "card_component.rb", <<~RUBY
             class CardComponent < Phlex::Component
               def template(&)
-                article(class: "drop-shadow rounded p-5", &)
+                ARTICLE(class: "drop-shadow rounded p-5", &)
               end
             end
           RUBY
@@ -109,7 +109,7 @@ module Pages
               end
 
               def template
-                h1 "Hello \#{@name}!"
+                H1 "Hello \#{@name}!"
               end
             end
           RUBY
@@ -137,7 +137,7 @@ module Pages
               end
 
               def template
-                h1 "Hello \#{@name}!"
+                H1 "Hello \#{@name}!"
               end
             end
           RUBY
@@ -169,7 +169,7 @@ module Pages
               end
 
               def template
-                span status_emoji
+                SPAN status_emoji
               end
 
               private

--- a/docs/pages/templates.rb
+++ b/docs/pages/templates.rb
@@ -7,7 +7,7 @@ module Pages
 
           Rather than use another langauge like ERB, HAML or Slim, Phlex provides a Ruby DSL for defining HTML templates.
 
-          You can create a component class by subclassing `Phlex::Component` and defining a method called `template`. Within the `template` method, you can compose HTML markup by calling the name of any [HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element).
+          You can create a component class by subclassing `Phlex::Component` and defining a method called `template`. Within the `template` method, you can compose HTML markup by calling the all-caps name of any [HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element).
 
           The first argument to an HTML element method is the _text content_ for that element. For example, here’s a component with an `<h1>` element that says “Hello World!”
         MD
@@ -16,7 +16,7 @@ module Pages
           e.tab "heading_component.rb", <<~RUBY
             class HeadingComponent < Phlex::Component
               def template
-                h1 "Hello World!"
+                H1 "Hello World!"
               end
             end
           RUBY
@@ -36,7 +36,7 @@ module Pages
           e.tab "heading_component.rb", <<~RUBY
             class HeadingComponent < Phlex::Component
               def template
-                h1 "Hello World!",
+                H1 "Hello World!",
                   class: "text-xl font-bold",
                   aria_details: "details"
               end
@@ -54,8 +54,8 @@ module Pages
           e.tab "example_component.rb", <<~RUBY
             class ExampleComponent < Phlex::Component
               def template
-                input type: "radio", name: "channel", id: "1", checked: true
-                input type: "radio", name: "channel", id: "2", checked: false
+                INPUT type: "radio", name: "channel", id: "1", checked: true
+                INPUT type: "radio", name: "channel", id: "2", checked: false
               end
             end
           RUBY
@@ -73,11 +73,11 @@ module Pages
           e.tab "nav_component.rb", <<~RUBY
             class NavComponent < Phlex::Component
               def template
-                nav do
-                  ul do
-                    li { a "Home", href: "/" }
-                    li { a "About", href: "/about" }
-                    li { a "Contact", href: "/contact" }
+                NAV do
+                  UL do
+                    LI { A "Home", href: "/" }
+                    LI { A "About", href: "/about" }
+                    LI { A "Contact", href: "/contact" }
                   end
                 end
               end
@@ -97,7 +97,7 @@ module Pages
           e.tab "heading_component.rb", <<~RUBY
             class HeadingComponent < Phlex::Component
               def template
-                h1 { strong "Hello "; text "World!" }
+                H1 { STRONG "Hello "; text "World!" }
               end
             end
           RUBY
@@ -115,36 +115,16 @@ module Pages
           e.tab "example_component.rb", <<~RUBY
             class LinksComponent < Phlex::Component
               def template
-                a "Home", href: "/"
+                A "Home", href: "/"
                 whitespace
-                a "About", href: "/about"
+                A "About", href: "/about"
                 whitespace
-                a "Contact", href: "/contact"
+                A "Contact", href: "/contact"
               end
             end
           RUBY
 
           e.execute "LinksComponent.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          ## The template element
-
-          Because the `template` method is used to define the component template itself, you need to use the method `template_tag` if you want to to render an HTML `<template>` tag.
-        MD
-
-        render Example.new do |e|
-          e.tab "example_component.rb", <<~RUBY
-            class ExampleComponent < Phlex::Component
-              def template
-                template_tag do
-                  img src: "hidden.jpg", alt: "A hidden image."
-                end
-              end
-            end
-          RUBY
-
-          e.execute "ExampleComponent.new.call"
         end
       end
     end

--- a/examples/layout.rb
+++ b/examples/layout.rb
@@ -5,23 +5,23 @@ module Example
     end
 
     def template(&block)
-      html do
-        head do
-          title @title
-          meta name: "viewport", content: "width=device-width,initial-scale=1"
-          link href: "/assets/tailwind.css", rel: "stylesheet"
+      HTML do
+        HEAD do
+          TITLE @title
+          META name: "viewport", content: "width=device-width,initial-scale=1"
+          LINK href: "/assets/tailwind.css", rel: "stylesheet"
         end
 
-        body class: "bg-zinc-100" do
-          nav class: "p-5", id: "main_nav" do
-            ul do
-              li(class: "p-5") { a "Home", href: "/" }
-              li(class: "p-5") { a "About", href: "/about" }
-              li(class: "p-5") { a "Contact", href: "/contact" }
+        BODY class: "bg-zinc-100" do
+          NAV class: "p-5", id: "main_nav" do
+            UL do
+              LI(class: "p-5") { A "Home", href: "/" }
+              LI(class: "p-5") { A "About", href: "/about" }
+              LI(class: "p-5") { A "Contact", href: "/contact" }
             end
           end
 
-          div class: "container mx-auto p-5", &block
+          DIV class: "container mx-auto p-5", &block
         end
       end
     end

--- a/examples/page.rb
+++ b/examples/page.rb
@@ -2,31 +2,31 @@ module Example
   class Page < Phlex::Component
     def template
       render LayoutComponent.new do
-        h1 "Hi"
+        H1 "Hi"
 
         5.times do
-          div do
+          DIV do
             10.times do
-              a "Test", href: "something", unique: SecureRandom.uuid
+              A "Test", href: "something", unique: SecureRandom.uuid
             end
           end
         end
 
-        table do
-          thead do
+        TABLE do
+          THEAD do
             10.times do
-              tr do
-                th "Hi"
+              TR do
+                TH "Hi"
               end
             end
           end
 
-          tbody do
+          TBODY do
             100.times do
-              tr class: "a b c d e f g", id: "something" do
+              TR class: "a b c d e f g", id: "something" do
                 10.times do
-                  td class: "f g h i j k l" do
-                    span "Test"
+                  TD class: "f g h i j k l" do
+                    SPAN "Test"
                   end
                 end
               end

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -24,11 +24,7 @@ module Phlex
             raise ArgumentError, "Custom elements must be provided as Symbols"
           end
 
-          class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-            def #{tag_name}(*args, **kwargs, &block)
-              _standard_element(*args, _name: "#{tag_name.to_s.gsub('_', '-')}", **kwargs, &block)
-            end
-          RUBY
+          alias_method tag_name.upcase, :_standard_element
         end
       end
     end

--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -30,15 +30,9 @@ module Phlex
       @_target << content
     end
 
-    def template_tag(*args, **kwargs, &block)
-      _standard_element(*args, _name: "template", **kwargs, &block)
-    end
-
     def _standard_element(content = nil, _name: nil, **kwargs, &block)
       raise ArgumentError if content && block_given?
-
-      name = _name ||= __callee__.name
-
+      name = (Tag::TAGS[__callee__] ||= __callee__.name.downcase.gsub(Tag::UNDERSCORE, Tag::DASH))
       @_target << Tag::LEFT << name
       _attributes(kwargs) if kwargs.length > 0
       @_target << Tag::RIGHT
@@ -53,7 +47,8 @@ module Phlex
     end
 
     def _void_element(**kwargs)
-      @_target << Tag::LEFT << __callee__.name
+      name = (Tag::TAGS[__callee__] ||= __callee__.name.downcase.gsub(Tag::UNDERSCORE, Tag::DASH))
+      @_target << Tag::LEFT << name
       _attributes(kwargs) if kwargs.length > 0
       @_target << Tag::CLOSE_VOID_RIGHT
     end
@@ -89,11 +84,11 @@ module Phlex
     end
 
     Tag::STANDARD_ELEMENTS.each do |tag_name|
-      alias_method tag_name, :_standard_element
+      alias_method tag_name.upcase, :_standard_element
     end
 
     Tag::VOID_ELEMENTS.each do |tag_name|
-      alias_method tag_name, :_void_element
+      alias_method tag_name.upcase, :_void_element
     end
   end
 end

--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -2,6 +2,7 @@
 
 module Phlex
   module Tag
+    TAGS = {}
     DASH = "-"
     SPACE = " "
     UNDERSCORE = "_"

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -3,7 +3,7 @@ ApplicationController = Class.new(ActionController::Base)
 
 class CardComponent < Phlex::Component
   def template(&block)
-    article class: "p-5 rounded drop-shadow", &block
+    ARTICLE class: "p-5 rounded drop-shadow", &block
   end
 end
 
@@ -25,7 +25,7 @@ RSpec.describe Phlex::Component do
   let(:component) do
     Class.new Phlex::Component do
       def template
-        h1 "Hi"
+        H1 "Hi"
       end
     end
   end
@@ -34,7 +34,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          div class: SecureRandom.hex
+          DIV class: SecureRandom.hex
         end
       end
     end
@@ -104,9 +104,9 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          a "Home"
+          A "Home"
           whitespace
-          a "About"
+          A "About"
         end
       end
     end
@@ -121,9 +121,9 @@ RSpec.describe Phlex::Component do
       Class.new Phlex::Component do
         def template
           doctype
-          html do
-            head do
-              title "Hello"
+          HTML do
+            HEAD do
+              TITLE "Hello"
             end
           end
         end
@@ -139,7 +139,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          article id: %{"><script type="text/javascript" src="bad_script.js"></script>}
+          ARTICLE id: %{"><script type="text/javascript" src="bad_script.js"></script>}
         end
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          article %{"><script type="text/javascript" src="bad_script.js"></script>}
+          ARTICLE %{"><script type="text/javascript" src="bad_script.js"></script>}
         end
       end
     end
@@ -167,7 +167,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          article(**attributes)
+          ARTICLE(**attributes)
         end
 
         def attributes
@@ -187,7 +187,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          article(onkeyup: "alert(1);")
+          ARTICLE(onkeyup: "alert(1);")
         end
       end
     end
@@ -201,7 +201,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          a "Javascript link", href: "javascript:javascript:alert(1)"
+          A "Javascript link", href: "javascript:javascript:alert(1)"
         end
       end
     end
@@ -215,7 +215,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          h1 "Hello", id: "foo", disabled: true, visible: false, aria_hidden: "true"
+          H1 "Hello", id: "foo", disabled: true, visible: false, aria_hidden: "true"
         end
       end
     end
@@ -237,7 +237,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          img src: "/logo.png", alt: "Logo"
+          IMG src: "/logo.png", alt: "Logo"
         end
       end
     end
@@ -263,10 +263,10 @@ RSpec.describe Phlex::Component do
         end
 
         def template
-          nav {
-            ul {
-              li @status
-              li status_emoji
+          NAV {
+            UL {
+              LI @status
+              LI status_emoji
             }
           }
         end
@@ -297,7 +297,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          div class: "a b c"
+          DIV class: "a b c"
         end
       end
     end
@@ -315,7 +315,7 @@ RSpec.describe Phlex::Component do
         end
 
         def template
-          html { head { title @title } }
+          HTML { HEAD { TITLE @title } }
         end
       end
     end
@@ -331,7 +331,7 @@ RSpec.describe Phlex::Component do
     let :component do
       Class.new Phlex::Component do
         def template
-          h1 "Rendered twice"
+          H1 "Rendered twice"
         end
       end
     end
@@ -352,10 +352,10 @@ RSpec.describe Phlex::Component do
           end
 
           def template
-            main {
+            MAIN {
               render(CardComponent.new) {
-                h1 @status
-                h2 status_emoji
+                H1 @status
+                H2 status_emoji
               }
             }
           end
@@ -390,9 +390,9 @@ RSpec.describe Phlex::Component do
           register_element :trix_editor, :trix_toolbar
 
           def template
-            div {
-              trix_toolbar
-              trix_editor "Hello"
+            DIV {
+              TRIX_TOOLBAR()
+              TRIX_EDITOR "Hello"
             }
           end
         end


### PR DESCRIPTION
To avoid conflicts with other method names such as [Kernel#p](https://rubyapi.org/3.1/o/kernel#method-i-p) and `Phlex::Component#template` we could make all the tag methods uppercase.

I don't think it looks or feels as nice as it did before, but ultimately I do think this could lead to a better developer experience. It's entirely reasonable, for example, to define a `title` method and then try to output that in a `<title>` element.

Before, this could have resulted in an infinite loop. Now, it just works.

```diff
def template
-  title(title)
+  TITLE(title)
end

def title
  ...
end
```

One downside is all-caps method calls without arguments will be treated as constant references unless they have empty parens.

Some other options:
1. Live with the potential conflicts — it's very unlikely anyone will need to use Kernel#p from a Phlex component and it's not difficult to avoid new conflicts.
2. Underscore prefix, e.g. `_p`
3. Underscore suffix, e.g. `p_`
4. `_tag` suffix, e.g. `p_tag`