### PR TITLE
Table component

### DIFF
--- a/lib/phlex/collection.rb
+++ b/lib/phlex/collection.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Phlex
+	class Collection < Phlex::View
+		def initialize(collection: nil, item: nil)
+			unless collection || item
+				raise ArgumentError,
+					"You must pass a collection or an item as a keyword argument."
+			end
+
+			if collection && item
+				raise ArgumentError,
+					"You can pass either a collection or an item as a keyword argument but not both."
+			end
+
+			@collection = collection or @item = item
+		end
+
+		def template
+			@collection ? collection_template : item_template
+		end
+
+		private
+
+		def yield_items
+			if @item
+				raise NoMethodError,
+					"You can only yield_items when rendering a collection. You're already rendering an item."
+			end
+
+			@collection.each do |item|
+				render self.class.new(item: item)
+			end
+		end
+	end
+end

--- a/lib/phlex/table.rb
+++ b/lib/phlex/table.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Phlex
+	class Table < Phlex::Collection
+		class << self
+			def property(header, &block)
+				if header.is_a?(String)
+					header_text = header
+					header = -> { text header_text }
+				end
+
+				properties << {
+					header: header,
+					body: block
+				}
+			end
+
+			def properties
+				@properties ||= []
+			end
+		end
+
+		def collection_template
+			table do
+				thead do
+					tr do
+						self.class.properties.each do |property|
+							th scope: "col" do
+								instance_exec(&property[:header])
+							end
+						end
+					end
+				end
+
+				tbody { yield_items }
+			end
+		end
+
+		def item_template
+			tr do
+				self.class.properties.each do |property|
+					td do
+						instance_exec(@item, &property[:body])
+					end
+				end
+			end
+		end
+	end
+end


### PR DESCRIPTION
First-party `Phlex::Table` component allows you to build HTML tables with a DSL. First define the table:

```ruby
class Articles::Table < Phlex::Table
  property "Title" do |article|
    a article.title, href: articles_path(article)
  end

  property "Publication date", &:published_at
  property "Comments", &:comments_count
end
```

Then pass it a list of resources:

```ruby
render Articles::Table.new(collection: @articles)
```

Or a single resource to render a fragment:
```ruby
render Articles::Table.new(item: @article)
```