### PR TITLE
Define tag methods with macros

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -2,6 +2,7 @@
 
 module Phlex
   class Component
+    extend Tag
     include Context, Renderable
 
     class << self
@@ -16,20 +17,6 @@ module Phlex
         end
 
         component
-      end
-
-      def register_element(*tag_names)
-        tag_names.each do |tag_name|
-          unless tag_name.is_a? Symbol
-            raise ArgumentError, "Custom elements must be provided as Symbols"
-          end
-
-          class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-            def #{tag_name}(*args, **kwargs, &block)
-              _standard_element(*args, _name: "#{tag_name.to_s.gsub('_', '-')}", **kwargs, &block)
-            end
-          RUBY
-        end
       end
     end
 

--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
+  using Overrides::Symbol::Name
+end
+
 module Phlex
   module Tag
     DASH = "-"
@@ -7,9 +11,7 @@ module Phlex
     UNDERSCORE = "_"
     NAMESPACE_DELINEATOR = "::"
 
-    LEFT = "<"
     RIGHT = ">"
-    CLOSE_LEFT = "</"
     CLOSE_VOID_RIGHT = " />"
 
     EQUALS_QUOTE = '="'
@@ -17,117 +19,40 @@ module Phlex
 
     DOCTYPE = "<!DOCTYPE html>"
 
-    EVENT_ATTRIBUTES = %i[onabort onafterprint onbeforeprint onbeforeunload onblur oncanplay oncanplaythrough onchange onclick oncontextmenu oncopy oncuechange oncut ondblclick ondrag ondragend ondragenter ondragleave ondragover ondragstart ondrop ondurationchange onemptied onended onerror onerror onfocus onhashchange oninput oninvalid onkeydown onkeypress onkeyup onload onloadeddata onloadedmetadata onloadstart onmessage onmousedown onmousemove onmouseout onmouseover onmouseup onmousewheel onoffline ononline onpagehide onpageshow onpaste onpause onplay onplaying onpopstate onprogress onratechange onreset onresize onscroll onsearch onseeked onseeking onselect onstalled onstorage onsubmit onsuspend ontimeupdate ontoggle onunload onvolumechange onwaiting onwheel].to_h { [_1, true] }
+    EVENT_ATTRIBUTES = %i[onabort onafterprint onbeforeprint onbeforeunload onblur oncanplay oncanplaythrough onchange onclick oncontextmenu oncopy oncuechange oncut ondblclick ondrag ondragend ondragenter ondragleave ondragover ondragstart ondrop ondurationchange onemptied onended onerror onerror onfocus onhashchange oninput oninvalid onkeydown onkeypress onkeyup onload onloadeddata onloadedmetadata onloadstart onmessage onmousedown onmousemove onmouseout onmouseover onmouseup onmousewheel onoffline ononline onpagehide onpageshow onpaste onpause onplay onplaying onpopstate onprogress onratechange onreset onresize onscroll onsearch onseeked onseeking onselect onstalled onstorage onsubmit onsuspend ontimeupdate ontoggle onunload onvolumechange onwaiting onwheel].to_h { [_1, true] }.freeze
 
-    STANDARD_ELEMENTS = %w[
-      a
-      abbr
-      address
-      article
-      aside
-      b
-      bdi
-      bdo
-      blockquote
-      body
-      button
-      caption
-      cite
-      code
-      colgroup
-      data
-      datalist
-      dd
-      del
-      details
-      dfn
-      dialog
-      div
-      dl
-      dt
-      em
-      fieldset
-      figcaption
-      figure
-      footer
-      form
-      h1
-      h2
-      h3
-      h4
-      h5
-      h6
-      head
-      header
-      html
-      i
-      iframe
-      ins
-      kbd
-      label
-      legend
-      li
-      link
-      main
-      map
-      mark
-      menuitem
-      meta
-      meter
-      nav
-      noscript
-      object
-      ol
-      optgroup
-      option
-      output
-      p
-      picture
-      pre
-      progress
-      q
-      rp
-      rt
-      ruby
-      s
-      samp
-      script
-      section
-      select
-      slot
-      small
-      span
-      strong
-      style
-      sub
-      summary
-      sup
-      table
-      tbody
-      td
-      textarea
-      tfoot
-      th
-      thead
-      time
-      title
-      tr
-      u
-      ul
-      video
-      wbr
-    ].freeze
+    STANDARD_ELEMENTS = %i[a abbr address article aside b bdi bdo blockquote body button caption cite code colgroup data datalist dd del details dfn dialog div dl dt em fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header html i iframe ins kbd label legend li main map mark menuitem meter nav noscript object ol optgroup option output p picture pre progress q rp rt ruby s samp script section select slot small span strong style sub summary sup table tbody td textarea tfoot th thead time title tr u ul video wbr].freeze
 
-    VOID_ELEMENTS = %w[
-      area
-      embed
-      img
-      input
-      link
-      meta
-      param
-      track
-      col
-    ].freeze
+    VOID_ELEMENTS = %i[area embed img input link meta param track col].freeze
+
+    def register_element(element, tag: element.name.gsub(Tag::UNDERSCORE, Tag::DASH))
+      class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        def #{element}(content = nil, _name: nil, **kwargs, &block)
+          raise ArgumentError if content && block_given?
+
+          @_target << "<#{tag}"
+          _attributes(kwargs) if kwargs.length > 0
+          @_target << Tag::RIGHT
+
+          if block_given?
+            content(&block)
+          else
+            text content if content
+          end
+
+          @_target << "</#{tag}>"
+        end
+      RUBY
+    end
+
+    def register_void_element(element, tag: element.name.gsub(Tag::UNDERSCORE, Tag::DASH))
+      class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        def #{element}(**kwargs)
+          @_target << "<#{tag}"
+          _attributes(kwargs) if kwargs.length > 0
+          @_target << Tag::CLOSE_VOID_RIGHT
+        end
+      RUBY
+    end
   end
 end

--- a/spec/phlex/component_spec.rb
+++ b/spec/phlex/component_spec.rb
@@ -387,7 +387,8 @@ RSpec.describe Phlex::Component do
     describe "with custom elements" do
       let :component do
         Class.new Phlex::Component do
-          register_element :trix_editor, :trix_toolbar
+          register_element :trix_editor
+          register_element :trix_toolbar
 
           def template
             div {
@@ -400,19 +401,6 @@ RSpec.describe Phlex::Component do
 
       it "produces the correct markup" do
         expect(output).to eq "<div><trix-toolbar></trix-toolbar><trix-editor>Hello</trix-editor></div>"
-      end
-
-      describe "with invalid tags" do
-        let :component do
-          Class.new Phlex::Component do
-            register_element "NOT-VALID"
-          end
-        end
-
-        it "raises an ArgumentError" do
-          expect { component }.to raise_error(ArgumentError,
-            "Custom elements must be provided as Symbols")
-        end
       end
     end
   end


### PR DESCRIPTION
Use macros to define the tag methods instead of `alias_method` with `__callee__`. This enables us to preemptively generate the entire opening and closing strings so there's less runtime concatenation. 

Before
```
Warming up --------------------------------------
                Page    71.000  i/100ms
Calculating -------------------------------------
                Page    714.729  (± 0.3%) i/s -      3.621k in   5.066311s
```

After
```
Warming up --------------------------------------
                Page    90.000  i/100ms
Calculating -------------------------------------
                Page    905.819  (± 0.3%) i/s -      4.590k in   5.067280s
```