### PR TITLE
Fast path for elements without attributes

### DIFF
--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -30,9 +30,13 @@ module Phlex
         def #{element}(content = nil, _name: nil, **kwargs, &block)
           raise ArgumentError if content && block_given?
 
-          @_target << "<#{tag}"
-          _attributes(kwargs) if kwargs.length > 0
-          @_target << Tag::RIGHT
+          if kwargs.length > 0
+            @_target << "<#{tag}"
+            _attributes(kwargs)
+            @_target << Tag::RIGHT
+          else
+            @_target << "<#{tag}>"
+          end
 
           if block_given?
             content(&block)
@@ -48,9 +52,13 @@ module Phlex
     def register_void_element(element, tag: element.name.gsub(Tag::UNDERSCORE, Tag::DASH))
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
         def #{element}(**kwargs)
-          @_target << "<#{tag}"
-          _attributes(kwargs) if kwargs.length > 0
-          @_target << Tag::CLOSE_VOID_RIGHT
+          if kwargs.length > 0
+            @_target << "<#{tag}"
+            _attributes(kwargs)
+            @_target << Tag::CLOSE_VOID_RIGHT
+          else
+            @_target << "<#{tag} />"
+          end
         end
       RUBY
     end


### PR DESCRIPTION
We can preemptively build the entire opening tag when there are no attributes.

Before
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    90.000  i/100ms
Calculating -------------------------------------
                Page    903.564  (± 0.2%) i/s -      4.590k in   5.079905s
```

After
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    94.000  i/100ms
Calculating -------------------------------------
                Page    938.864  (± 0.2%) i/s -      4.700k in   5.006072s
```