### PR TITLE
Use frozen string literals in macros

### DIFF
--- a/lib/phlex/tag.rb
+++ b/lib/phlex/tag.rb
@@ -27,6 +27,8 @@ module Phlex
 
     def register_element(element, tag: element.name.gsub(Tag::UNDERSCORE, Tag::DASH))
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        # frozen_string_literal: true
+
         def #{element}(content = nil, _name: nil, **kwargs, &block)
           raise ArgumentError if content && block_given?
 
@@ -51,6 +53,8 @@ module Phlex
 
     def register_void_element(element, tag: element.name.gsub(Tag::UNDERSCORE, Tag::DASH))
       class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        # frozen_string_literal: true
+
         def #{element}(**kwargs)
           if kwargs.length > 0
             @_target << "<#{tag}"


### PR DESCRIPTION
Before
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page    93.000  i/100ms
Calculating -------------------------------------
                Page    929.093  (± 0.2%) i/s -      4.650k in   5.004908s
```

After
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page   101.000  i/100ms
Calculating -------------------------------------
                Page      1.013k (± 0.2%) i/s -      5.151k in   5.084143s
```