### PR TITLE
Tokens and classes

### DIFF
--- a/docs/components/markdown.rb
+++ b/docs/components/markdown.rb
@@ -6,9 +6,9 @@ module Components
       def header(text, level)
         case level
         when 1
-          Title.new { text }.call
+          Title.new.call { text }
         else
-          Heading.new { text }.call
+          Heading.new.call { text }
         end
       end
     end

--- a/docs/pages/templates.rb
+++ b/docs/pages/templates.rb
@@ -130,6 +130,94 @@ module Pages
         end
 
         render Markdown.new(<<~MD)
+          ## Tokens and classes
+
+          The `tokens` method helps you define conditional HTML attribute tokens (such as CSS classes).
+
+          The `tokens` method accepts a splat of tokens that should always be output, and accepts keyword arguments for conditional tokens.
+
+          The keyword arguments allow you to specify under which conditions certain tokens are applicable. The keyword argument keys are the conditions and the values are the tokens. Conditions can be Procs or Symbols that map to a relevant method. The `:active?` Symbol, for example, maps to the `active?` instance method.
+
+          Here we have a `Link` component that produces an `<a>` tag with the CSS class `nav-item`. And if the link is _active_, we also apply the CSS class `nav-item-active`.
+        MD
+
+        render Example.new do |e|
+          e.tab "link.rb", <<~RUBY
+            class Link < Phlex::Component
+              def initialize(text, to:, active:)
+                @text = text
+                @to = to
+                @active = active
+              end
+
+              def template
+                a @text, href: @to, class: tokens("nav-item",
+                  active?: "nav-item-active")
+              end
+
+              private
+
+              def active? = @active
+            end
+          RUBY
+
+          e.tab "example.rb", <<~RUBY
+            class Example < Phlex::Component
+              def template
+                nav do
+                  ul do
+                    li { render Link.new("Home", to: "/", active: true) }
+                    li { render Link.new("About", to: "/about", active: false) }
+                  end
+                end
+              end
+            end
+          RUBY
+
+          e.execute "Example.new.call"
+        end
+
+        render Markdown.new(<<~MD)
+          You can also use the `classes` helper method to create a token list of classes. Since this method returns a hash (e.g. `{ class: "your CSS classes here" }`), you can destructure it into a `class:` keyword argument using the `**` prefix operator.
+        MD
+
+        render Example.new do |e|
+          e.tab "link.rb", <<~RUBY
+            class Link < Phlex::Component
+              def initialize(text, to:, active:)
+                @text = text
+                @to = to
+                @active = active
+              end
+
+              def template
+                a @text, href: @to, **classes("nav-item",
+                  active?: "nav-item-active")
+              end
+
+              private
+
+              def active? = @active
+            end
+          RUBY
+
+          e.tab "example.rb", <<~RUBY
+            class Example < Phlex::Component
+              def template
+                nav do
+                  ul do
+                    li { render Link.new("Home", to: "/", active: true) }
+                    li { render Link.new("About", to: "/about", active: false) }
+                  end
+                end
+              end
+            end
+          RUBY
+
+          e.execute "Example.new.call"
+        end
+
+        render Markdown.new(<<~MD)
           ## The template element
 
           Because the `template` method is used to define the component template itself, you need to use the method `template_tag` if you want to to render an HTML `<template>` tag.

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -66,6 +66,32 @@ module Phlex
       @_target << content
     end
 
+    def classes(*tokens, **conditional_tokens)
+      { class: self.tokens(*tokens, **conditional_tokens) }
+    end
+
+    def tokens(*tokens, **conditional_tokens)
+      conditional_tokens.each do |condition, token|
+        case condition
+        when Symbol then next unless send(condition)
+        when Proc then next unless condition.call
+        else
+          raise ArgumentError, "The class condition must be a Symbol or a Proc."
+        end
+
+        case token
+        when Symbol then tokens << token.name
+        when String then tokens << token
+        when Array then tokens.concat(t)
+        else
+          raise ArgumentError,
+            "Conditional classes must be Symbols, Strings, or Arrays of Symbols or Strings."
+        end
+      end
+
+      tokens.compact.join(" ")
+    end
+
     def _attributes(attributes, buffer: +"")
       if attributes[:href]&.start_with?(/\s*javascript/)
         attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "")

--- a/test/phlex/component/tokens.rb
+++ b/test/phlex/component/tokens.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Phlex::Component do
+  extend ComponentHelper
+
+  with "conditional classes" do
+    with "symbol conditionals" do
+      component do
+        def template
+          a "Home", href: "/", **classes("a", "b", "c", active?: "active", primary?: "primary")
+        end
+
+        def active?
+          false
+        end
+
+        def primary?
+          true
+        end
+      end
+
+      it "works" do
+        expect(output).to be ==
+          %(<a href="/" class="a b c primary">Home</a>)
+      end
+    end
+
+    with "proc conditionals" do
+      component do
+        def template
+          a "Home", href: "/", **classes("a", "b", "c",
+            -> { true } => "true",
+            -> { false } => "false")
+        end
+      end
+
+      it "works" do
+        expect(output).to be ==
+          %(<a href="/" class="a b c true">Home</a>)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the ability to use conditional tokens for attributes, based on the idea behind [token_list](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-token_list) in Rails. Although the goal is the same, there are some important differences between Rails’ `token_list` and Phlex `tokens`.

Phlex tokens are not split and de-duplicated. This is in my opinion an entirely unnecessary step with a significant performance cost.

I’ve also decided to use a different method signature. With Phlex tokens, the conditions — provided as Symbols or Procs — come first, followed by the values. There are two advantages to this:

1. Putting the condition first makes it easier to scan for a specific condition down the left-hand side of the code.
2. It also means we can avoid potential subtle bugs if the same value key is provided for different conditions.

In this example, we override the `"font-bold"` condition and set it to `primary?` _instead_ of `active?` rather than `primary? || active?`.

```ruby
token_list("font-bold" => active?, "font-bold" => primary?)
```

Using symbol conditions as keys means we can avoid this, since values are not required to be unique and we delay execution of the keys.

```ruby
tokens(active?: "font-bold", primary?: "font-bold")
```

In addition to `tokens`, there's also a `classes` method, which delegates to `tokens` returning the result in `{ class: tokens(...) }` hash. `classes` can be directly splatted into the arguments for a tag:

```ruby
div **classes("a b c", active?: "font-bold")
```