### PR TITLE
Only strip javascript from links if there is javascript

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -86,7 +86,9 @@ module Phlex
 
       buffer = first_render ? buffer = +"" : buffer = @_target
 
-      attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "") if attributes[:href]
+      if attributes[:href]&.start_with?(/\s*javascript/)
+        attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "")
+      end
 
       attributes.each do |k, v|
         next unless v


### PR DESCRIPTION
`start_with?` is faster than `sub` and links with javascript in them are uncommon, so this adds a fast check using `start_with?` before stripping with `sub`.