### PR TITLE
Faster attributes

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -78,10 +78,6 @@ module Phlex
     end
 
     def _attributes(attributes)
-      if (cached = Phlex::ATTRIBUTE_CACHE[attributes.hash])
-        return @_target << cached
-      end
-
       first_render = !self.class.rendered_at_least_once
 
       buffer = first_render ? buffer = +"" : buffer = @_target
@@ -97,8 +93,13 @@ module Phlex
           raise ArgumentError, "Unsafe attribute name detected: #{k}."
         end
 
-        if v == true
+        case v
+        when true
           buffer << " " << k.name.tr("_", "-")
+        when String
+          buffer << " " << k.name.tr("_", "-") << '="' << CGI.escape_html(v) << '"'
+        when Symbol
+          buffer << " " << k.name.tr("_", "-") << '="' << CGI.escape_html(v.name) << '"'
         else
           buffer << " " << k.name.tr("_", "-") << '="' << CGI.escape_html(v.to_s) << '"'
         end

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -20,8 +20,12 @@ module Phlex
 
         def #{element}(content = nil, **attributes, &block)
           if attributes.length > 0
-            @_target << "<#{tag}"
-            _attributes(attributes)
+            if (cached = Phlex::ATTRIBUTE_CACHE[attributes.hash])
+              @_target << "<#{tag}" << cached
+            else
+              @_target << "<#{tag}"
+              _attributes(attributes)
+            end
             if content
               @_target << ">" << CGI.escape_html(content) << "</#{tag}>"
             elsif block_given?
@@ -52,9 +56,13 @@ module Phlex
 
         def #{element}(**attributes)
           if attributes.length > 0
-            @_target << "<#{tag}"
-            _attributes(attributes)
-            @_target << " />"
+            if (cached = Phlex::ATTRIBUTE_CACHE[attributes.hash])
+              @_target << "<#{tag}" << cached << " />"
+            else
+              @_target << "<#{tag}"
+              _attributes(attributes)
+              @_target << " />"
+            end
           else
             @_target << "<#{tag} />"
           end


### PR DESCRIPTION
Before
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page   111.000  i/100ms
Calculating -------------------------------------
                Page      1.117k (± 0.4%) i/s -      5.661k in   5.069957s
```

After
```
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
Warming up --------------------------------------
                Page   113.000  i/100ms
Calculating -------------------------------------
                Page      1.136k (± 0.1%) i/s -      5.763k in   5.071220s
```