### PR TITLE
Remove default component initializer

### DIFF
--- a/docs/components/layout.rb
+++ b/docs/components/layout.rb
@@ -3,7 +3,7 @@ module Components
     register_element :style
 
     def initialize(title:)
-      super
+      @title = title
     end
 
     def template(&)

--- a/docs/components/tabs/tab.rb
+++ b/docs/components/tabs/tab.rb
@@ -2,7 +2,8 @@ module Components
   class Tabs
     class Tab < Phlex::Component
       def initialize(name:, checked:)
-        super
+        @name = name
+        @checked = checked
       end
 
       def template(&)

--- a/docs/pages/components.rb
+++ b/docs/pages/components.rb
@@ -126,34 +126,6 @@ module Pages
         end
 
         render Markdown.new(<<~MD)
-          The default initializer in `Phlex::Component` sets each given keyword argument to an instance variable, so the above could be re-written to call `super` instead.
-        MD
-
-        render Example.new do |e|
-          e.tab "hello.rb", <<~RUBY
-            class Hello < Phlex::Component
-              def initialize(name:)
-                super
-              end
-
-              def template
-                h1 "Hello \#{@name}!"
-              end
-            end
-          RUBY
-
-          e.tab "example.rb", <<~RUBY
-            class Example < Phlex::Component
-              def template
-                render Hello.new(name: "Joel")
-              end
-            end
-          RUBY
-
-          e.execute "Example.new.call"
-        end
-
-        render Markdown.new(<<~MD)
           It’s usually a good idea to use instance variables directly rather than creating accessor methods for them. Otherwise it’s easy to run into naming conflicts. For example, your layout component might have the attribute `title`, to render into a `<title>` element in the document head. If you define `attr_accessor :title`, that would overwrite the `title` method for creating `<title>` elements.
 
           ## Calculations with methods
@@ -165,7 +137,7 @@ module Pages
           e.tab "status.rb", <<~RUBY
             class Status < Phlex::Component
               def initialize(status:)
-                super
+                @status = status
               end
 
               def template

--- a/fixtures/layout.rb
+++ b/fixtures/layout.rb
@@ -1,7 +1,7 @@
 module Example
   class LayoutComponent < Phlex::Component
     def initialize(title: "Example")
-      super
+      @title = title
     end
 
     def template(&block)

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -24,10 +24,6 @@ module Phlex
       end
     end
 
-    def initialize(**attributes)
-      attributes.each { |k, v| instance_variable_set("@#{k}", v) }
-    end
-
     def call(buffer = +"", view_context: nil, parent: nil, &block)
       raise "The same component instance shouldn't be rendered twice" if @_rendered
 


### PR DESCRIPTION
The default component initialiser is really slow. If there's enough demand, we could perhaps have a class method that defines an initialiser for you.