### PR TITLE
Public `raw` method

### DIFF
--- a/docs/components/code_block.rb
+++ b/docs/components/code_block.rb
@@ -11,7 +11,7 @@ module Components
 
     def template
       pre(class: "highlight p-5 whitespace-pre-wrap bg-stone-50") {
-        _raw FORMATTER.format(
+        raw FORMATTER.format(
           lexer.lex(@code)
         )
       }

--- a/docs/components/layout.rb
+++ b/docs/components/layout.rb
@@ -16,7 +16,7 @@ module Components
           meta charset: "utf-8"
           title @title
           link href: "/application.css", rel: "stylesheet"
-          style { _raw Rouge::Theme.find("github").render(scope: ".highlight") }
+          style { raw Rouge::Theme.find("github").render(scope: ".highlight") }
         end
 
         body class: "p-12" do

--- a/docs/components/markdown.rb
+++ b/docs/components/markdown.rb
@@ -20,7 +20,7 @@ module Components
     end
 
     def template
-      _raw MARKDOWN.render(@content)
+      raw MARKDOWN.render(@content)
     end
   end
 end

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -62,7 +62,7 @@ module Phlex
       @_target << HTML::DOCTYPE
     end
 
-    def _raw(content)
+    def raw(content)
       @_target << content
     end
 

--- a/test/phlex/component/raw.rb
+++ b/test/phlex/component/raw.rb
@@ -8,7 +8,7 @@ describe Phlex::Component do
   with "raw content" do
     component do
       def template
-        _raw %(<h1 class="test">Hello</h1>)
+        raw %(<h1 class="test">Hello</h1>)
       end
     end
 


### PR DESCRIPTION
Rename `_raw` to `raw` to make it part of the public API for components.