### PR TITLE
Fix renderable class check

### DIFF
--- a/lib/phlex/renderable.rb
+++ b/lib/phlex/renderable.rb
@@ -9,7 +9,7 @@ module Phlex
         end
 
         renderable.call(@_target, view_context: @_view_context, parent: self, &block)
-      elsif renderable < Component
+      elsif renderable.is_a?(Class) && renderable < Component
         raise ArgumentError, "You tried to render the Phlex component class: #{renderable.name} but you probably meant to render an instance of that class instead."
       else
         @_target << @_view_context.render(renderable, *args, **kwargs, &block)


### PR DESCRIPTION
We shouldn’t call `<` on renderable unless we know it’s a Class.