### PR TITLE
Add SVG and PATH tags

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -8,7 +8,7 @@ module Phlex
   module HTML
     DOCTYPE = "<!DOCTYPE html>"
 
-    STANDARD_ELEMENTS = %i[a abbr address article aside b bdi bdo blockquote body button caption cite code colgroup data datalist dd del details dfn dialog div dl dt em fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header html i iframe ins kbd label legend li main map mark menuitem meter nav noscript object ol optgroup option output p picture pre progress q rp rt ruby s samp script section select slot small span strong style sub summary sup table tbody td textarea tfoot th thead time title tr u ul video wbr].freeze
+    STANDARD_ELEMENTS = %i[a abbr address article aside b bdi bdo blockquote body button caption cite code colgroup data datalist dd del details dfn dialog div dl dt em fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header html i iframe ins kbd label legend li main map mark menuitem meter nav noscript object ol optgroup option output p path picture pre progress q rp rt ruby s samp script section select slot small span strong style sub summary sup svg table tbody td textarea tfoot th thead time title tr u ul video wbr].freeze
 
     VOID_ELEMENTS = %i[area embed img input link meta param track col].freeze
 


### PR DESCRIPTION
This PR aims to add support for [`svg`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg) and [`path`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path) elements. 

