### PR TITLE
Implicitly convert component content to string

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -47,15 +47,20 @@ module Phlex
       return unless block_given?
 
       original_length = @_target.length
-      output = yield(self) if block_given?
+      output = yield(self)
       unchanged = (original_length == @_target.length)
 
-      text(output) if unchanged && output.is_a?(String)
+      text(output) if unchanged
       nil
     end
 
     def text(content)
-      @_target << CGI.escape_html(content)
+      @_target << case content
+      when String then CGI.escape_html(content)
+      when Symbol then CGI.escape_html(content.name)
+      else CGI.escape_html(content.to_s)
+      end
+
       nil
     end
 

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -31,7 +31,14 @@ module Phlex
             end
           else
             if content
-              @_target << "<#{tag}>" << CGI.escape_html(content) << "</#{tag}>"
+              case content
+              when String
+                @_target << "<#{tag}>" << CGI.escape_html(content) << "</#{tag}>"
+              when Symbol
+                @_target << "<#{tag}>" << CGI.escape_html(content.name) << "</#{tag}>"
+              else
+                @_target << "<#{tag}>" << CGI.escape_html(content.to_s) << "</#{tag}>"
+              end
             elsif block_given?
               @_target << "<#{tag}>"
               content(&block)

--- a/test/phlex/component/numbers.rb
+++ b/test/phlex/component/numbers.rb
@@ -5,39 +5,34 @@ require "test_helper"
 describe Phlex::Component do
   extend ComponentHelper
 
-  with "text" do
+  with "numbers" do
     component do
       def template
-        text "Hi"
+        span 1
+        span 2.0
       end
     end
 
     it "produces the correct output" do
-      expect(output).to be == "Hi"
+      expect(output).to be == "<span>1</span><span>2.0</span>"
     end
   end
 
-  with "int as text" do
+  with "numbers in block" do
     component do
       def template
-        text 1
+        span do
+          1
+        end
+
+        span do
+          2.0
+        end
       end
     end
 
     it "produces the correct output" do
-      expect(output).to be == "1"
-    end
-  end
-
-  with "float as text" do
-    component do
-      def template
-        text 2.0
-      end
-    end
-
-    it "produces the correct output" do
-      expect(output).to be == "2.0"
+      expect(output).to be == "<span>1</span><span>2.0</span>"
     end
   end
 end


### PR DESCRIPTION
This Pull Requests implicitly converts the given content to a string so you, as a user of the library, don't have to convert the content upfront before passing it to the `text` or any `html` method.

Resolves #163 