### PR TITLE
Add `<br />` element to `HTML::VOID_ELEMENTS`

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -10,7 +10,7 @@ module Phlex
 
     STANDARD_ELEMENTS = %i[a abbr address article aside b bdi bdo blockquote body button caption cite code colgroup data datalist dd del details dfn dialog div dl dt em fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header html i iframe ins kbd label legend li main map mark menuitem meter nav noscript object ol optgroup option output p path picture pre progress q rp rt ruby s samp script section select slot small span strong style sub summary sup svg table tbody td textarea tfoot th thead time title tr u ul video wbr].freeze
 
-    VOID_ELEMENTS = %i[area embed img input link meta param source track col].freeze
+    VOID_ELEMENTS = %i[area br embed img input link meta param source track col].freeze
 
     EVENT_ATTRIBUTES = %w[onabort onafterprint onbeforeprint onbeforeunload onblur oncanplay oncanplaythrough onchange onclick oncontextmenu oncopy oncuechange oncut ondblclick ondrag ondragend ondragenter ondragleave ondragover ondragstart ondrop ondurationchange onemptied onended onerror onerror onfocus onhashchange oninput oninvalid onkeydown onkeypress onkeyup onload onloadeddata onloadedmetadata onloadstart onmessage onmousedown onmousemove onmouseout onmouseover onmouseup onmousewheel onoffline ononline onpagehide onpageshow onpaste onpause onplay onplaying onpopstate onprogress onratechange onreset onresize onscroll onsearch onseeked onseeking onselect onstalled onstorage onsubmit onsuspend ontimeupdate ontoggle onunload onvolumechange onwaiting onwheel].to_h { [_1, true] }.freeze
 


### PR DESCRIPTION
I noticed the `<br />` tag was missing when testing the interoperability of the generated Phlex output of [`phlexing`](https://github.com/marcoroth/phlexing).