### PR TITLE
Spaces -> Tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,9 @@ inherit_from: "https://www.goodcop.style"
 
 AllCops:
   TargetRubyVersion: 2.7
+
+Layout/IndentationStyle:
+  EnforcedStyle: tabs
+
+Layout/IndentationWidth:
+  Width: 1

--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,8 @@
 require "bundler/gem_tasks"
 
 begin
-  require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:spec)
+	require "rspec/core/rake_task"
+	RSpec::Core::RakeTask.new(:spec)
 end
 
 task default: :spec

--- a/bench.rb
+++ b/bench.rb
@@ -10,5 +10,5 @@ require_relative "fixtures/layout"
 puts RUBY_DESCRIPTION
 
 Benchmark.ips do |x|
-  x.report("Page") { Example::Page.new.call }
+	x.report("Page") { Example::Page.new.call }
 end

--- a/bin/docs
+++ b/bin/docs
@@ -6,11 +6,11 @@ require "listen"
 system "bundle exec docs/build.rb"
 
 Listen.to("#{__dir__}/../docs/pages", "#{__dir__}/../docs/components") do |modified, added, removed|
-  puts modified
-  puts added
-  puts removed
+	puts modified
+	puts added
+	puts removed
 
-  system "bundle exec docs/build.rb"
+	system "bundle exec docs/build.rb"
 end.start
 
 system "ruby -run -e httpd docs/dist"

--- a/docs/build.rb
+++ b/docs/build.rb
@@ -8,10 +8,10 @@ require "fileutils"
 Bundler.require :docs
 
 Zeitwerk::Loader.new.tap do |loader|
-  loader.push_dir(__dir__)
-  loader.ignore(__FILE__)
-  loader.setup
-  loader.eager_load
+	loader.push_dir(__dir__)
+	loader.ignore(__FILE__)
+	loader.setup
+	loader.eager_load
 end
 
 FileUtils.mkdir_p("#{__dir__}/dist")

--- a/docs/components/callout.rb
+++ b/docs/components/callout.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Components
-  class Callout < Phlex::Component
-    def template(&block)
-      div(class: "rounded bg-orange-50 text-sm p-5 border border-orange-100", &block)
-    end
-  end
+	class Callout < Phlex::Component
+		def template(&block)
+			div(class: "rounded bg-orange-50 text-sm p-5 border border-orange-100", &block)
+		end
+	end
 end

--- a/docs/components/code_block.rb
+++ b/docs/components/code_block.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
 module Components
-  class CodeBlock < Phlex::Component
-    FORMATTER = Rouge::Formatters::HTML.new
+	class CodeBlock < Phlex::Component
+		FORMATTER = Rouge::Formatters::HTML.new
 
-    def initialize(code, syntax:)
-      @code = code
-      @syntax = syntax
-    end
+		def initialize(code, syntax:)
+			@code = code
+			@syntax = syntax
+		end
 
-    def template
-      pre(class: "highlight p-5 whitespace-pre-wrap bg-stone-50") {
-        raw FORMATTER.format(
-          lexer.lex(@code)
-        )
-      }
-    end
+		def template
+			pre(class: "highlight p-5 whitespace-pre-wrap bg-stone-50") {
+				raw FORMATTER.format(
+					lexer.lex(@code)
+				)
+			}
+		end
 
-    private
+		private
 
-    def lexer
-      Rouge::Lexer.find(@syntax)
-    end
-  end
+		def lexer
+			Rouge::Lexer.find(@syntax)
+		end
+	end
 end

--- a/docs/components/example.rb
+++ b/docs/components/example.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
 module Components
-  class Example < Phlex::Component
-    def initialize
-      @sandbox = Module.new
-    end
+	class Example < Phlex::Component
+		def initialize
+			@sandbox = Module.new
+		end
 
-    def template(&block)
-      render Tabs.new do |t|
-        @t = t
-        yield self
-      end
-    end
+		def template(&block)
+			render Tabs.new do |t|
+				@t = t
+				yield self
+			end
+		end
 
-    def tab(name, code)
-      @t.tab(name) do
-        render CodeBlock.new(code, syntax: :ruby)
-      end
+		def tab(name, code)
+			@t.tab(name) do
+				render CodeBlock.new(code, syntax: :ruby)
+			end
 
-      @sandbox.instance_eval(code)
-    end
+			@sandbox.instance_eval(code)
+		end
 
-    def execute(code)
-      output = @sandbox.instance_eval(code)
+		def execute(code)
+			output = @sandbox.instance_eval(code)
 
-      @t.tab("HTML Output") do
-        render CodeBlock.new(HtmlBeautifier.beautify(output), syntax: :html)
-      end
-    end
-  end
+			@t.tab("HTML Output") do
+				render CodeBlock.new(HtmlBeautifier.beautify(output), syntax: :html)
+			end
+		end
+	end
 end

--- a/docs/components/heading.rb
+++ b/docs/components/heading.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Components
-  class Heading < Phlex::Component
-    def template(&block)
-      h2(class: "text-xl font-bold mt-10 mb-5", &block)
-    end
-  end
+	class Heading < Phlex::Component
+		def template(&block)
+			h2(class: "text-xl font-bold mt-10 mb-5", &block)
+		end
+	end
 end

--- a/docs/components/layout.rb
+++ b/docs/components/layout.rb
@@ -1,45 +1,45 @@
 # frozen_string_literal: true
 
 module Components
-  class Layout < Phlex::Component
-    register_element :style
+	class Layout < Phlex::Component
+		register_element :style
 
-    def initialize(title:)
-      @title = title
-    end
+		def initialize(title:)
+			@title = title
+		end
 
-    def template(&block)
-      doctype
+		def template(&block)
+			doctype
 
-      html do
-        head do
-          meta charset: "utf-8"
-          title @title
-          link href: "/application.css", rel: "stylesheet"
-          style { raw Rouge::Theme.find("github").render(scope: ".highlight") }
-        end
+			html do
+				head do
+					meta charset: "utf-8"
+					title @title
+					link href: "/application.css", rel: "stylesheet"
+					style { raw Rouge::Theme.find("github").render(scope: ".highlight") }
+				end
 
-        body class: "p-12" do
-          div class: "max-w-screen-lg mx-auto grid grid-cols-4 gap-10" do
-            header class: "col-span-1" do
-              a(href: "/", class: "block") { img src: "/assets/logo.png", width: "150" }
+				body class: "p-12" do
+					div class: "max-w-screen-lg mx-auto grid grid-cols-4 gap-10" do
+						header class: "col-span-1" do
+							a(href: "/", class: "block") { img src: "/assets/logo.png", width: "150" }
 
-              nav do
-                ul do
-                  li { a "Introduction", href: "/" }
-                  li { a "Templates", href: "/templates" }
-                  li { a "Components", href: "/components" }
-                  li { a "Source code", href: "https://github.com/joeldrapper/phlex" }
-                end
-              end
-            end
+							nav do
+								ul do
+									li { a "Introduction", href: "/" }
+									li { a "Templates", href: "/templates" }
+									li { a "Components", href: "/components" }
+									li { a "Source code", href: "https://github.com/joeldrapper/phlex" }
+								end
+							end
+						end
 
-            main(class: "col-span-3", &block)
+						main(class: "col-span-3", &block)
 
-            footer class: "text-sm text-right col-span-4 py-10"
-          end
-        end
-      end
-    end
-  end
+						footer class: "text-sm text-right col-span-4 py-10"
+					end
+				end
+			end
+		end
+	end
 end

--- a/docs/components/markdown.rb
+++ b/docs/components/markdown.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
 module Components
-  class Markdown < Phlex::Component
-    class Render < Redcarpet::Render::HTML
-      def header(text, level)
-        case level
-        when 1
-          Title.new.call { text }
-        else
-          Heading.new.call { text }
-        end
-      end
-    end
+	class Markdown < Phlex::Component
+		class Render < Redcarpet::Render::HTML
+			def header(text, level)
+				case level
+				when 1
+					Title.new.call { text }
+				else
+					Heading.new.call { text }
+				end
+			end
+		end
 
-    MARKDOWN = Redcarpet::Markdown.new(Render.new, autolink: true, tables: true)
+		MARKDOWN = Redcarpet::Markdown.new(Render.new, autolink: true, tables: true)
 
-    def initialize(content)
-      @content = content
-    end
+		def initialize(content)
+			@content = content
+		end
 
-    def template
-      raw MARKDOWN.render(@content)
-    end
-  end
+		def template
+			raw MARKDOWN.render(@content)
+		end
+	end
 end

--- a/docs/components/tabs.rb
+++ b/docs/components/tabs.rb
@@ -1,30 +1,30 @@
 # frozen_string_literal: true
 
 module Components
-  class Tabs < Phlex::Component
-    def initialize
-      @index = 1
-    end
+	class Tabs < Phlex::Component
+		def initialize
+			@index = 1
+		end
 
-    def template(&block)
-      div class: "tabs flex flex-wrap relative my-5", role: "tablist" do
-        content(&block)
-      end
-    end
+		def template(&block)
+			div class: "tabs flex flex-wrap relative my-5", role: "tablist" do
+				content(&block)
+			end
+		end
 
-    def tab(name, &block)
-      render(Tab.new(name: name, checked: first?), &block)
-      @index += 1
-    end
+		def tab(name, &block)
+			render(Tab.new(name: name, checked: first?), &block)
+			@index += 1
+		end
 
-    def unique_identifier
-      @unique_identifier ||= SecureRandom.hex
-    end
+		def unique_identifier
+			@unique_identifier ||= SecureRandom.hex
+		end
 
-    private
+		private
 
-    def first?
-      @index == 1
-    end
-  end
+		def first?
+			@index == 1
+		end
+	end
 end

--- a/docs/components/tabs/tab.rb
+++ b/docs/components/tabs/tab.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
 
 module Components
-  class Tabs
-    class Tab < Phlex::Component
-      def initialize(name:, checked:)
-        @name = name
-        @checked = checked
-      end
+	class Tabs
+		class Tab < Phlex::Component
+			def initialize(name:, checked:)
+				@name = name
+				@checked = checked
+			end
 
-      def template(&block)
-        input class: "opacity-0 fixed peer", type: "radio", name: @_parent.unique_identifier, id: unique_identifier, checked: @checked
+			def template(&block)
+				input class: "opacity-0 fixed peer", type: "radio", name: @_parent.unique_identifier, id: unique_identifier, checked: @checked
 
-        label @name, id: "#{unique_identifier}-label", for: unique_identifier, role: "tab", aria_controls: "#{unique_identifier}-panel", class: "order-1 py-2 px-5 bg-white text-sm border border-b-0 border-l-0 font-medium first-of-type:border-l first-of-type:rounded-tl last-of-type:rounded-tr before:absolute before:pointer-events-none before:w-full before:ring before:h-full before:left-0 before:top-0 before:hidden before:rounded peer-focus:before:block cursor-pointer"
+				label @name, id: "#{unique_identifier}-label", for: unique_identifier, role: "tab", aria_controls: "#{unique_identifier}-panel", class: "order-1 py-2 px-5 bg-white text-sm border border-b-0 border-l-0 font-medium first-of-type:border-l first-of-type:rounded-tl last-of-type:rounded-tr before:absolute before:pointer-events-none before:w-full before:ring before:h-full before:left-0 before:top-0 before:hidden before:rounded peer-focus:before:block cursor-pointer"
 
-        div id: "#{unique_identifier}-panel", role: "tabpanel", aria_labelledby: "#{unique_identifier}-label", class: "tab hidden order-2 w-full border rounded-b rounded-tr overflow-hidden" do
-          @_parent.instance_exec(&block)
-        end
-      end
+				div id: "#{unique_identifier}-panel", role: "tabpanel", aria_labelledby: "#{unique_identifier}-label", class: "tab hidden order-2 w-full border rounded-b rounded-tr overflow-hidden" do
+					@_parent.instance_exec(&block)
+				end
+			end
 
-      def unique_identifier
-        @unique_identifier ||= SecureRandom.hex
-      end
-    end
-  end
+			def unique_identifier
+				@unique_identifier ||= SecureRandom.hex
+			end
+		end
+	end
 end

--- a/docs/components/title.rb
+++ b/docs/components/title.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Components
-  class Title < Phlex::Component
-    def template(&block)
-      h1(class: "text-2xl font-bold my-5", &block)
-    end
-  end
+	class Title < Phlex::Component
+		def template(&block)
+			h1(class: "text-2xl font-bold my-5", &block)
+		end
+	end
 end

--- a/docs/page_builder.rb
+++ b/docs/page_builder.rb
@@ -1,36 +1,36 @@
 # frozen_string_literal: true
 
 class PageBuilder
-  ROOT = Pages::ApplicationPage
+	ROOT = Pages::ApplicationPage
 
-  def self.build_all
-    ROOT.subclasses.each { |page| new(page).call }
-  end
+	def self.build_all
+		ROOT.subclasses.each { |page| new(page).call }
+	end
 
-  def initialize(page)
-    @page = page
-  end
+	def initialize(page)
+		@page = page
+	end
 
-  def call
-    FileUtils.mkdir_p(directory)
-    File.write(file, @page.new.call)
-  end
+	def call
+		FileUtils.mkdir_p(directory)
+		File.write(file, @page.new.call)
+	end
 
-  private
+	private
 
-  def file
-    "#{directory}/index.html"
-  end
+	def file
+		"#{directory}/index.html"
+	end
 
-  def directory
-    if path == "index"
-      "#{__dir__}/dist"
-    else
-      "#{__dir__}/dist/#{path}"
-    end
-  end
+	def directory
+		if path == "index"
+			"#{__dir__}/dist"
+		else
+			"#{__dir__}/dist/#{path}"
+		end
+	end
 
-  def path
-    @page.name.downcase.split("::")[1..].join("/")
-  end
+	def path
+		@page.name.downcase.split("::")[1..].join("/")
+	end
 end

--- a/docs/pages/application_page.rb
+++ b/docs/pages/application_page.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Pages
-  class ApplicationPage < Phlex::Component
-    include ::Components
-  end
+	class ApplicationPage < Phlex::Component
+		include ::Components
+	end
 end

--- a/docs/pages/components.rb
+++ b/docs/pages/components.rb
@@ -1,175 +1,175 @@
 # frozen_string_literal: true
 
 module Pages
-  class Components < ApplicationPage
-    def template
-      render Layout.new(title: "Components in Phlex") do
-        render Markdown.new(<<~MD)
-          # Components
+	class Components < ApplicationPage
+		def template
+			render Layout.new(title: "Components in Phlex") do
+				render Markdown.new(<<~MD)
+     # Components
 
-          ## Yielding content
+     ## Yielding content
 
-          Your components can accept content as a block passed to the template method. You can capture the content block and pass it to the `content` method to yield it.
-        MD
+     Your components can accept content as a block passed to the template method. You can capture the content block and pass it to the `content` method to yield it.
+				MD
 
-        render Example.new do |e|
-          e.tab "card.rb", <<~RUBY
-            class Card < Phlex::Component
-              def template(&)
-                article(class: "drop-shadow rounded p-5") {
-                  h1 "Amazing content!"
-                  content(&)
-                }
-              end
-            end
-          RUBY
-
-          e.execute "Card.new.call { 'Your content here.\n' }"
-        end
-
-        render Markdown.new(<<~MD)
-          ## Delegating content
-
-          Alternatively, you can pass the content down as an argument to another component or tag.
-        MD
-
-        render Example.new do |e|
-          e.tab "card.rb", <<~RUBY
-            class Card < Phlex::Component
-              def template(&)
-                article(class: "drop-shadow rounded p-5", &)
-              end
-            end
-          RUBY
-
-          e.execute "Card.new.call { 'Your content here.' }"
-        end
-
-        render Markdown.new(<<~MD)
-          ## Nested components
-
-          Components can render other components and optionally pass them content as a block.
-        MD
-
-        render Example.new do |e|
-          e.tab "example.rb", <<~RUBY
-            class Example < Phlex::Component
-              def template
-                render Card.new do
-                  h1 "Hello"
-                end
-              end
-            end
-          RUBY
-
-          e.tab "card.rb", <<~RUBY
-            class Card < Phlex::Component
-              def template(&)
-                article(class: "drop-shadow rounded p-5", &)
-              end
-            end
-          RUBY
-
-          e.execute "Example.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          If the block just wraps a string, the string is treated as _text content_.
-        MD
-
-        render Example.new do |e|
-          e.tab "example.rb", <<~RUBY
-            class Example < Phlex::Component
-              def template
-                render(Card.new) { "Hi" }
-              end
-            end
-          RUBY
-
-          e.tab "card.rb", <<~RUBY
-            class Card < Phlex::Component
-              def template(&)
-                article(class: "drop-shadow rounded p-5", &)
-              end
-            end
-          RUBY
-
-          e.execute "Example.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          ## Component attributes
-
-          Besides content, components can define attributes in an initializer, which can then be rendered in the template.
-        MD
-
-        render Example.new do |e|
-          e.tab "hello.rb", <<~RUBY
-            class Hello < Phlex::Component
-              def initialize(name:)
-                @name = name
-              end
-
-              def template
-                h1 "Hello \#{@name}!"
-              end
-            end
-          RUBY
-
-          e.tab "example.rb", <<~RUBY
-            class Example < Phlex::Component
-              def template
-                render Hello.new(name: "Joel")
-              end
-            end
-          RUBY
-
-          e.execute "Example.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          It’s usually a good idea to use instance variables directly rather than creating accessor methods for them. Otherwise it’s easy to run into naming conflicts. For example, your layout component might have the attribute `title`, to render into a `<title>` element in the document head. If you define `attr_accessor :title`, that would overwrite the `title` method for creating `<title>` elements.
-
-          ## Calculations with methods
-
-          Components are just Ruby classes, so you can perform calculations on component attributes by defining your own methods.
-        MD
-
-        render Example.new do |e|
-          e.tab "status.rb", <<~RUBY
-            class Status < Phlex::Component
-              def initialize(status:)
-                @status = status
-              end
-
-              def template
-                span status_emoji
-              end
-
-              private
-
-              def status_emoji
-                case @status
-                when :success
-                  "✅"
-                when :failure
-                  "❌"
-                end
-              end
-            end
-          RUBY
-
-          e.tab "example.rb", <<~RUBY
-            class Example < Phlex::Component
-              def template
-                render Status.new(status: :success)
-              end
-            end
-          RUBY
-
-          e.execute "Example.new.call"
+				render Example.new do |e|
+					e.tab "card.rb", <<~RUBY
+      class Card < Phlex::Component
+        def template(&)
+          article(class: "drop-shadow rounded p-5") {
+            h1 "Amazing content!"
+            content(&)
+          }
         end
       end
-    end
-  end
+					RUBY
+
+					e.execute "Card.new.call { 'Your content here.\n' }"
+				end
+
+				render Markdown.new(<<~MD)
+     ## Delegating content
+
+     Alternatively, you can pass the content down as an argument to another component or tag.
+				MD
+
+				render Example.new do |e|
+					e.tab "card.rb", <<~RUBY
+      class Card < Phlex::Component
+        def template(&)
+          article(class: "drop-shadow rounded p-5", &)
+        end
+      end
+					RUBY
+
+					e.execute "Card.new.call { 'Your content here.' }"
+				end
+
+				render Markdown.new(<<~MD)
+     ## Nested components
+
+     Components can render other components and optionally pass them content as a block.
+				MD
+
+				render Example.new do |e|
+					e.tab "example.rb", <<~RUBY
+      class Example < Phlex::Component
+        def template
+          render Card.new do
+            h1 "Hello"
+          end
+        end
+      end
+					RUBY
+
+					e.tab "card.rb", <<~RUBY
+      class Card < Phlex::Component
+        def template(&)
+          article(class: "drop-shadow rounded p-5", &)
+        end
+      end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     If the block just wraps a string, the string is treated as _text content_.
+				MD
+
+				render Example.new do |e|
+					e.tab "example.rb", <<~RUBY
+      class Example < Phlex::Component
+        def template
+          render(Card.new) { "Hi" }
+        end
+      end
+					RUBY
+
+					e.tab "card.rb", <<~RUBY
+      class Card < Phlex::Component
+        def template(&)
+          article(class: "drop-shadow rounded p-5", &)
+        end
+      end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     ## Component attributes
+
+     Besides content, components can define attributes in an initializer, which can then be rendered in the template.
+				MD
+
+				render Example.new do |e|
+					e.tab "hello.rb", <<~RUBY
+      class Hello < Phlex::Component
+        def initialize(name:)
+          @name = name
+        end
+
+        def template
+          h1 "Hello \#{@name}!"
+        end
+      end
+					RUBY
+
+					e.tab "example.rb", <<~RUBY
+      class Example < Phlex::Component
+        def template
+          render Hello.new(name: "Joel")
+        end
+      end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     It’s usually a good idea to use instance variables directly rather than creating accessor methods for them. Otherwise it’s easy to run into naming conflicts. For example, your layout component might have the attribute `title`, to render into a `<title>` element in the document head. If you define `attr_accessor :title`, that would overwrite the `title` method for creating `<title>` elements.
+
+     ## Calculations with methods
+
+     Components are just Ruby classes, so you can perform calculations on component attributes by defining your own methods.
+				MD
+
+				render Example.new do |e|
+					e.tab "status.rb", <<~RUBY
+      class Status < Phlex::Component
+        def initialize(status:)
+          @status = status
+        end
+
+        def template
+          span status_emoji
+        end
+
+        private
+
+        def status_emoji
+          case @status
+          when :success
+            "✅"
+          when :failure
+            "❌"
+          end
+        end
+      end
+					RUBY
+
+					e.tab "example.rb", <<~RUBY
+      class Example < Phlex::Component
+        def template
+          render Status.new(status: :success)
+        end
+      end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
+			end
+		end
+	end
 end

--- a/docs/pages/index.rb
+++ b/docs/pages/index.rb
@@ -1,40 +1,40 @@
 # frozen_string_literal: true
 
 module Pages
-  class Index < ApplicationPage
-    def template
-      render Layout.new(title: "Introduction to Phlex") do
-        render Markdown.new(<<~MD)
-          # Introduction
+	class Index < ApplicationPage
+		def template
+			render Layout.new(title: "Introduction to Phlex") do
+				render Markdown.new(<<~MD)
+     # Introduction
 
-          Phlex is a framework for building fast, reusable, testable view components in pure Ruby.
+     Phlex is a framework for building fast, reusable, testable view components in pure Ruby.
 
-          Think of a component as anything on a web page that you could draw a circle around and name. Starting on the outside, you have the _“page”_ itself, inside the page is a _“header”_, in the header is a _“nav bar”_ and in the nav bar is a _“nav bar item.”_ These objects together make up an entire page and we call the objects components.
+     Think of a component as anything on a web page that you could draw a circle around and name. Starting on the outside, you have the _“page”_ itself, inside the page is a _“header”_, in the header is a _“nav bar”_ and in the nav bar is a _“nav bar item.”_ These objects together make up an entire page and we call the objects components.
 
-          Each component object is an instance of a specific class of component. The nav-bar, for example, might contain three different nav-bar-items, but they’re all instances of the nav-bar-item class. This class, then, manifests everything there is to know about nav bar items in general. It models:
+     Each component object is an instance of a specific class of component. The nav-bar, for example, might contain three different nav-bar-items, but they’re all instances of the nav-bar-item class. This class, then, manifests everything there is to know about nav bar items in general. It models:
 
-          1. the **data** attributes being represented — perhaps url and label;
-          2. a **template**, which dictates how the data should be represented with HTML markup and CSS classes; and
-          3. **logic**, conditions, or calculations on the data — perhaps a predicate method to determine whether the link is active or not.
+     1. the **data** attributes being represented — perhaps url and label;
+     2. a **template**, which dictates how the data should be represented with HTML markup and CSS classes; and
+     3. **logic**, conditions, or calculations on the data — perhaps a predicate method to determine whether the link is active or not.
 
-          # Why use Phlex?
+     # Why use Phlex?
 
-          ## Better developer experience 🎉
+     ## Better developer experience 🎉
 
-          You don’t need to introduce a new language like Slim, HAML, or ERB. Phlex components are plain old Ruby objects: component classes are just Ruby classes, templates are just methods, and HTML tags are just method calls. If you know how to define a method that calls another method, you pretty much already know how to use Phlex.
+     You don’t need to introduce a new language like Slim, HAML, or ERB. Phlex components are plain old Ruby objects: component classes are just Ruby classes, templates are just methods, and HTML tags are just method calls. If you know how to define a method that calls another method, you pretty much already know how to use Phlex.
 
-          ## Better safety 🥽
-          Rails partials can implicitly depend on instance variables from a controller or view. This happens more often than you might think when copying code into a new partial extraction. If the partial is then rendered in a different context or the instance variable’s meaning changes, things can break quite severely without warning.
+     ## Better safety 🥽
+     Rails partials can implicitly depend on instance variables from a controller or view. This happens more often than you might think when copying code into a new partial extraction. If the partial is then rendered in a different context or the instance variable’s meaning changes, things can break quite severely without warning.
 
-          Conversely, Phlex component templates render in an isolated execution context where only the instance variables and methods for the specific component are exposed.
+     Conversely, Phlex component templates render in an isolated execution context where only the instance variables and methods for the specific component are exposed.
 
-          ## Better performance 🚀
+     ## Better performance 🚀
 
-          Phlex is ~4.35× faster than ActionView and ~2× faster than ViewComponent. Phlex components are also streamable.
+     Phlex is ~4.35× faster than ActionView and ~2× faster than ViewComponent. Phlex components are also streamable.
 
-          Rails apps typically spend 40-80% of the response time rendering views, so this could be a significant factor in overall app performance.
-        MD
-      end
-    end
-  end
+     Rails apps typically spend 40-80% of the response time rendering views, so this could be a significant factor in overall app performance.
+				MD
+			end
+		end
+	end
 end

--- a/docs/pages/templates.rb
+++ b/docs/pages/templates.rb
@@ -1,242 +1,242 @@
 # frozen_string_literal: true
 
 module Pages
-  class Templates < ApplicationPage
-    def template
-      render Layout.new(title: "Templates in Phlex") do
-        render Markdown.new(<<~MD)
-          # Templates
+	class Templates < ApplicationPage
+		def template
+			render Layout.new(title: "Templates in Phlex") do
+				render Markdown.new(<<~MD)
+     # Templates
 
-          Rather than use another langauge like ERB, HAML or Slim, Phlex provides a Ruby DSL for defining HTML templates.
+     Rather than use another langauge like ERB, HAML or Slim, Phlex provides a Ruby DSL for defining HTML templates.
 
-          You can create a component class by subclassing `Phlex::Component` and defining a method called `template`. Within the `template` method, you can compose HTML markup by calling the name of any [HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element).
+     You can create a component class by subclassing `Phlex::Component` and defining a method called `template`. Within the `template` method, you can compose HTML markup by calling the name of any [HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element).
 
-          The first argument to an HTML element method is the _text content_ for that element. For example, here’s a component with an `<h1>` element that says “Hello World!”
-        MD
+     The first argument to an HTML element method is the _text content_ for that element. For example, here’s a component with an `<h1>` element that says “Hello World!”
+				MD
 
-        render Example.new do |e|
-          e.tab "heading.rb", <<~RUBY
-            class Heading < Phlex::Component
-              def template
-                h1 "Hello World!"
-              end
-            end
-          RUBY
-
-          e.execute "Heading.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          The text content is always HTML-escaped, so it’s safe to use with user input.
-
-          ## Attributes
-
-          You can add attributes to HTML elements by passing keyword arguments to the tag method. Underscores (`_`) in attribute names are automatically converted to dashes (`-`).
-        MD
-
-        render Example.new do |e|
-          e.tab "heading.rb", <<~RUBY
-            class Heading < Phlex::Component
-              def template
-                h1 "Hello World!",
-                  class: "text-xl font-bold",
-                  aria_details: "details"
-              end
-            end
-          RUBY
-
-          e.execute "Heading.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          You can also use *boolean* attributes. When set to `true`, the attribute will be rendered without a value, when _falsy_, the attribute isn’t rendered at all.
-        MD
-
-        render Example.new do |e|
-          e.tab "example.rb", <<~RUBY
-            class Example < Phlex::Component
-              def template
-                input type: "radio", name: "channel", id: "1", checked: true
-                input type: "radio", name: "channel", id: "2", checked: false
-              end
-            end
-          RUBY
-
-          e.execute "Example.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          ## Nesting
-
-          Pass a block to an element method to nest other elements inside it.
-        MD
-
-        render Example.new do |e|
-          e.tab "nav.rb", <<~RUBY
-            class Nav < Phlex::Component
-              def template
-                nav do
-                  ul do
-                    li { a "Home", href: "/" }
-                    li { a "About", href: "/about" }
-                    li { a "Contact", href: "/contact" }
-                  end
-                end
-              end
-            end
-          RUBY
-
-          e.execute "Nav.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          ## Stand-alone text
-
-          You can also output text without wrapping it in an element by using the `text` method. All text content is HTML-escaped, so it’s safe to use with user input.
-        MD
-
-        render Example.new do |e|
-          e.tab "heading.rb", <<~RUBY
-            class Heading < Phlex::Component
-              def template
-                h1 { strong "Hello "; text "World!" }
-              end
-            end
-          RUBY
-
-          e.execute "Heading.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          ## Whitespace
-
-          While the examples on this page have been formatted for readability, there is usually no whitespace between HTML tags. If you need to add some whitespace, you can use the `whitespace` method. This is useful for adding space between _inline_ elements to allow them to wrap.
-        MD
-
-        render Example.new do |e|
-          e.tab "links.rb", <<~RUBY
-            class Links < Phlex::Component
-              def template
-                a "Home", href: "/"
-                whitespace
-                a "About", href: "/about"
-                whitespace
-                a "Contact", href: "/contact"
-              end
-            end
-          RUBY
-
-          e.execute "Links.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          ## Tokens and classes
-
-          The `tokens` method helps you define conditional HTML attribute tokens (such as CSS classes).
-
-          The `tokens` method accepts a splat of tokens that should always be output, and accepts keyword arguments for conditional tokens.
-
-          The keyword arguments allow you to specify under which conditions certain tokens are applicable. The keyword argument keys are the conditions and the values are the tokens. Conditions can be Procs or Symbols that map to a relevant method. The `:active?` Symbol, for example, maps to the `active?` instance method.
-
-          Here we have a `Link` component that produces an `<a>` tag with the CSS class `nav-item`. And if the link is _active_, we also apply the CSS class `nav-item-active`.
-        MD
-
-        render Example.new do |e|
-          e.tab "link.rb", <<~RUBY
-            class Link < Phlex::Component
-              def initialize(text, to:, active:)
-                @text = text
-                @to = to
-                @active = active
-              end
-
-              def template
-                a @text, href: @to, class: tokens("nav-item",
-                  active?: "nav-item-active")
-              end
-
-              private
-
-              def active? = @active
-            end
-          RUBY
-
-          e.tab "example.rb", <<~RUBY
-            class Example < Phlex::Component
-              def template
-                nav do
-                  ul do
-                    li { render Link.new("Home", to: "/", active: true) }
-                    li { render Link.new("About", to: "/about", active: false) }
-                  end
-                end
-              end
-            end
-          RUBY
-
-          e.execute "Example.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          You can also use the `classes` helper method to create a token list of classes. Since this method returns a hash (e.g. `{ class: "your CSS classes here" }`), you can destructure it into a `class:` keyword argument using the `**` prefix operator.
-        MD
-
-        render Example.new do |e|
-          e.tab "link.rb", <<~RUBY
-            class Link < Phlex::Component
-              def initialize(text, to:, active:)
-                @text = text
-                @to = to
-                @active = active
-              end
-
-              def template
-                a @text, href: @to, **classes("nav-item",
-                  active?: "nav-item-active")
-              end
-
-              private
-
-              def active? = @active
-            end
-          RUBY
-
-          e.tab "example.rb", <<~RUBY
-            class Example < Phlex::Component
-              def template
-                nav do
-                  ul do
-                    li { render Link.new("Home", to: "/", active: true) }
-                    li { render Link.new("About", to: "/about", active: false) }
-                  end
-                end
-              end
-            end
-          RUBY
-
-          e.execute "Example.new.call"
-        end
-
-        render Markdown.new(<<~MD)
-          ## The template element
-
-          Because the `template` method is used to define the component template itself, you need to use the method `template_tag` if you want to to render an HTML `<template>` tag.
-        MD
-
-        render Example.new do |e|
-          e.tab "example.rb", <<~RUBY
-            class Example < Phlex::Component
-              def template
-                template_tag do
-                  img src: "hidden.jpg", alt: "A hidden image."
-                end
-              end
-            end
-          RUBY
-
-          e.execute "Example.new.call"
+				render Example.new do |e|
+					e.tab "heading.rb", <<~RUBY
+      class Heading < Phlex::Component
+        def template
+          h1 "Hello World!"
         end
       end
-    end
-  end
+					RUBY
+
+					e.execute "Heading.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     The text content is always HTML-escaped, so it’s safe to use with user input.
+
+     ## Attributes
+
+     You can add attributes to HTML elements by passing keyword arguments to the tag method. Underscores (`_`) in attribute names are automatically converted to dashes (`-`).
+				MD
+
+				render Example.new do |e|
+					e.tab "heading.rb", <<~RUBY
+      class Heading < Phlex::Component
+        def template
+          h1 "Hello World!",
+            class: "text-xl font-bold",
+            aria_details: "details"
+        end
+      end
+					RUBY
+
+					e.execute "Heading.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     You can also use *boolean* attributes. When set to `true`, the attribute will be rendered without a value, when _falsy_, the attribute isn’t rendered at all.
+				MD
+
+				render Example.new do |e|
+					e.tab "example.rb", <<~RUBY
+      class Example < Phlex::Component
+        def template
+          input type: "radio", name: "channel", id: "1", checked: true
+          input type: "radio", name: "channel", id: "2", checked: false
+        end
+      end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     ## Nesting
+
+     Pass a block to an element method to nest other elements inside it.
+				MD
+
+				render Example.new do |e|
+					e.tab "nav.rb", <<~RUBY
+      class Nav < Phlex::Component
+        def template
+          nav do
+            ul do
+              li { a "Home", href: "/" }
+              li { a "About", href: "/about" }
+              li { a "Contact", href: "/contact" }
+            end
+          end
+        end
+      end
+					RUBY
+
+					e.execute "Nav.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     ## Stand-alone text
+
+     You can also output text without wrapping it in an element by using the `text` method. All text content is HTML-escaped, so it’s safe to use with user input.
+				MD
+
+				render Example.new do |e|
+					e.tab "heading.rb", <<~RUBY
+      class Heading < Phlex::Component
+        def template
+          h1 { strong "Hello "; text "World!" }
+        end
+      end
+					RUBY
+
+					e.execute "Heading.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     ## Whitespace
+
+     While the examples on this page have been formatted for readability, there is usually no whitespace between HTML tags. If you need to add some whitespace, you can use the `whitespace` method. This is useful for adding space between _inline_ elements to allow them to wrap.
+				MD
+
+				render Example.new do |e|
+					e.tab "links.rb", <<~RUBY
+      class Links < Phlex::Component
+        def template
+          a "Home", href: "/"
+          whitespace
+          a "About", href: "/about"
+          whitespace
+          a "Contact", href: "/contact"
+        end
+      end
+					RUBY
+
+					e.execute "Links.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     ## Tokens and classes
+
+     The `tokens` method helps you define conditional HTML attribute tokens (such as CSS classes).
+
+     The `tokens` method accepts a splat of tokens that should always be output, and accepts keyword arguments for conditional tokens.
+
+     The keyword arguments allow you to specify under which conditions certain tokens are applicable. The keyword argument keys are the conditions and the values are the tokens. Conditions can be Procs or Symbols that map to a relevant method. The `:active?` Symbol, for example, maps to the `active?` instance method.
+
+     Here we have a `Link` component that produces an `<a>` tag with the CSS class `nav-item`. And if the link is _active_, we also apply the CSS class `nav-item-active`.
+				MD
+
+				render Example.new do |e|
+					e.tab "link.rb", <<~RUBY
+      class Link < Phlex::Component
+        def initialize(text, to:, active:)
+          @text = text
+          @to = to
+          @active = active
+        end
+
+        def template
+          a @text, href: @to, class: tokens("nav-item",
+            active?: "nav-item-active")
+        end
+
+        private
+
+        def active? = @active
+      end
+					RUBY
+
+					e.tab "example.rb", <<~RUBY
+      class Example < Phlex::Component
+        def template
+          nav do
+            ul do
+              li { render Link.new("Home", to: "/", active: true) }
+              li { render Link.new("About", to: "/about", active: false) }
+            end
+          end
+        end
+      end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     You can also use the `classes` helper method to create a token list of classes. Since this method returns a hash (e.g. `{ class: "your CSS classes here" }`), you can destructure it into a `class:` keyword argument using the `**` prefix operator.
+				MD
+
+				render Example.new do |e|
+					e.tab "link.rb", <<~RUBY
+      class Link < Phlex::Component
+        def initialize(text, to:, active:)
+          @text = text
+          @to = to
+          @active = active
+        end
+
+        def template
+          a @text, href: @to, **classes("nav-item",
+            active?: "nav-item-active")
+        end
+
+        private
+
+        def active? = @active
+      end
+					RUBY
+
+					e.tab "example.rb", <<~RUBY
+      class Example < Phlex::Component
+        def template
+          nav do
+            ul do
+              li { render Link.new("Home", to: "/", active: true) }
+              li { render Link.new("About", to: "/about", active: false) }
+            end
+          end
+        end
+      end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
+
+				render Markdown.new(<<~MD)
+     ## The template element
+
+     Because the `template` method is used to define the component template itself, you need to use the method `template_tag` if you want to to render an HTML `<template>` tag.
+				MD
+
+				render Example.new do |e|
+					e.tab "example.rb", <<~RUBY
+      class Example < Phlex::Component
+        def template
+          template_tag do
+            img src: "hidden.jpg", alt: "A hidden image."
+          end
+        end
+      end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
+			end
+		end
+	end
 end

--- a/fixtures/component_helper.rb
+++ b/fixtures/component_helper.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 module ComponentHelper
-  def self.extended(parent)
-    parent.instance_exec do
-      let(:output) { example.call }
-      let(:example) { component.new }
-    end
-  end
+	def self.extended(parent)
+		parent.instance_exec do
+			let(:output) { example.call }
+			let(:example) { component.new }
+		end
+	end
 
-  def component(&block)
-    let :component do
-      Class.new(Phlex::Component, &block)
-    end
-  end
+	def component(&block)
+		let :component do
+			Class.new(Phlex::Component, &block)
+		end
+	end
 end

--- a/fixtures/dummy/app/views/articles/form.rb
+++ b/fixtures/dummy/app/views/articles/form.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Views
-  module Articles
-    class Form < Phlex::Component
-      def template
-        form_with url: "test" do |f|
-          f.text_field :name
-        end
-      end
-    end
-  end
+	module Articles
+		class Form < Phlex::Component
+			def template
+				form_with url: "test" do |f|
+					f.text_field :name
+				end
+			end
+		end
+	end
 end

--- a/fixtures/dummy/app/views/card.rb
+++ b/fixtures/dummy/app/views/card.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Views
-  class Card < Phlex::Component
-    def template(&block)
-      article class: "drop-shadow p-5 rounded", &block
-    end
+	class Card < Phlex::Component
+		def template(&block)
+			article class: "drop-shadow p-5 rounded", &block
+		end
 
-    def title(text)
-      h3 text, class: "font-bold"
-    end
-  end
+		def title(text)
+			h3 text, class: "font-bold"
+		end
+	end
 end

--- a/fixtures/dummy/app/views/heading.rb
+++ b/fixtures/dummy/app/views/heading.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Views
-  class Heading < Phlex::Component
-    def template(&block)
-      h1(&block)
-    end
-  end
+	class Heading < Phlex::Component
+		def template(&block)
+			h1(&block)
+		end
+	end
 end

--- a/fixtures/dummy/config/routes.rb
+++ b/fixtures/dummy/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Rails routes here
+	# Rails routes here
 end

--- a/fixtures/dummy/db/schema.rb
+++ b/fixtures/dummy/db/schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define do
-  # Set up any tables you need to exist for your test suite that don't belong
-  # in migrations.
+	# Set up any tables you need to exist for your test suite that don't belong
+	# in migrations.
 end

--- a/fixtures/layout.rb
+++ b/fixtures/layout.rb
@@ -1,31 +1,31 @@
 # frozen_string_literal: true
 
 module Example
-  class LayoutComponent < Phlex::Component
-    def initialize(title: "Example")
-      @title = title
-    end
+	class LayoutComponent < Phlex::Component
+		def initialize(title: "Example")
+			@title = title
+		end
 
-    def template(&block)
-      html do
-        head do
-          title @title
-          meta name: "viewport", content: "width=device-width,initial-scale=1"
-          link href: "/assets/tailwind.css", rel: "stylesheet"
-        end
+		def template(&block)
+			html do
+				head do
+					title @title
+					meta name: "viewport", content: "width=device-width,initial-scale=1"
+					link href: "/assets/tailwind.css", rel: "stylesheet"
+				end
 
-        body class: "bg-zinc-100" do
-          nav class: "p-5", id: "main_nav" do
-            ul do
-              li(class: "p-5") { a "Home", href: "/" }
-              li(class: "p-5") { a "About", href: "/about" }
-              li(class: "p-5") { a "Contact", href: "/contact" }
-            end
-          end
+				body class: "bg-zinc-100" do
+					nav class: "p-5", id: "main_nav" do
+						ul do
+							li(class: "p-5") { a "Home", href: "/" }
+							li(class: "p-5") { a "About", href: "/about" }
+							li(class: "p-5") { a "Contact", href: "/contact" }
+						end
+					end
 
-          div class: "container mx-auto p-5", &block
-        end
-      end
-    end
-  end
+					div class: "container mx-auto p-5", &block
+				end
+			end
+		end
+	end
 end

--- a/fixtures/page.rb
+++ b/fixtures/page.rb
@@ -1,41 +1,41 @@
 # frozen_string_literal: true
 
 module Example
-  class Page < Phlex::Component
-    def template
-      render LayoutComponent.new do
-        h1 "Hi"
+	class Page < Phlex::Component
+		def template
+			render LayoutComponent.new do
+				h1 "Hi"
 
-        5.times do
-          div do
-            10.times do
-              a "Test", href: "something", unique: SecureRandom.uuid, data: { value: 1 }
-            end
-          end
-        end
+				5.times do
+					div do
+						10.times do
+							a "Test", href: "something", unique: SecureRandom.uuid, data: { value: 1 }
+						end
+					end
+				end
 
-        table do
-          thead do
-            10.times do
-              tr do
-                th "Hi"
-              end
-            end
-          end
+				table do
+					thead do
+						10.times do
+							tr do
+								th "Hi"
+							end
+						end
+					end
 
-          tbody do
-            100.times do
-              tr class: "a b c d e f g", id: "something" do
-                10.times do
-                  td class: "f g h i j k l" do
-                    span "Test"
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-    end
-  end
+					tbody do
+						100.times do
+							tr class: "a b c d e f g", id: "something" do
+								10.times do
+									td class: "f g h i j k l" do
+										span "Test"
+									end
+								end
+							end
+						end
+					end
+				end
+			end
+		end
+	end
 end

--- a/fixtures/test_helper.rb
+++ b/fixtures/test_helper.rb
@@ -7,7 +7,7 @@ Bundler.require :test
 
 Combustion.path = "fixtures/dummy"
 Combustion.initialize! :action_controller do
-  config.autoload_paths << "#{root}/app"
+	config.autoload_paths << "#{root}/app"
 end
 
 require "component_helper"

--- a/lib/generators/phlex/component/component_generator.rb
+++ b/lib/generators/phlex/component/component_generator.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Phlex
-  module Generators
-    class ComponentGenerator < ::Rails::Generators::NamedBase
-      source_root File.expand_path("templates", __dir__)
+	module Generators
+		class ComponentGenerator < ::Rails::Generators::NamedBase
+			source_root File.expand_path("templates", __dir__)
 
-      def create_component
-        template "component.rb", File.join("app/views", class_path, "#{file_name}.rb")
-      end
-    end
-  end
+			def create_component
+				template "component.rb", File.join("app/views", class_path, "#{file_name}.rb")
+			end
+		end
+	end
 end

--- a/lib/overrides/symbol/name.rb
+++ b/lib/overrides/symbol/name.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Overrides::Symbol::Name
-  refine(Symbol) { alias_method :name, :to_s }
+	refine(Symbol) { alias_method :name, :to_s }
 end

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -9,22 +9,22 @@ loader.inflector.inflect("html" => "HTML")
 loader.setup
 
 module Phlex
-  Error = Module.new
-  ArgumentError = Class.new(ArgumentError) { include Error }
+	Error = Module.new
+	ArgumentError = Class.new(ArgumentError) { include Error }
 
-  extend self
+	extend self
 
-  ATTRIBUTE_CACHE = {}
+	ATTRIBUTE_CACHE = {}
 
-  def configuration
-    @configuration ||= Configuration.new
-  end
+	def configuration
+		@configuration ||= Configuration.new
+	end
 
-  def configure
-    yield configuration
-  end
+	def configure
+		yield configuration
+	end
 end
 
 if defined?(Rails::Engine)
-  require "rails"
+	require "rails"
 end

--- a/lib/phlex/block.rb
+++ b/lib/phlex/block.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 module Phlex
-  class Block
-    def initialize(context, &block)
-      @context = context
-      @block = block
-    end
+	class Block
+		def initialize(context, &block)
+			@context = context
+			@block = block
+		end
 
-    def to_proc
-      method(:call).to_proc
-    end
+		def to_proc
+			method(:call).to_proc
+		end
 
-    def call(*args, **kwargs)
-      @context.instance_exec(*args, **kwargs, &@block)
-    end
-  end
+		def call(*args, **kwargs)
+			@context.instance_exec(*args, **kwargs, &@block)
+		end
+	end
 end

--- a/lib/phlex/buffered.rb
+++ b/lib/phlex/buffered.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 module Phlex
-  class Buffered
-    def initialize(object, buffer:)
-      @object, @buffer = object, buffer
-    end
+	class Buffered
+		def initialize(object, buffer:)
+			@object, @buffer = object, buffer
+		end
 
-    def method_missing(name, *args, **kwargs, &block)
-      output = @object.public_send(name, *args, **kwargs, &block)
-      @buffer << output if output.is_a? String
-      nil
-    end
+		def method_missing(name, *args, **kwargs, &block)
+			output = @object.public_send(name, *args, **kwargs, &block)
+			@buffer << output if output.is_a? String
+			nil
+		end
 
-    def respond_to_missing?(name)
-      @object.respond_to?(name)
-    end
-  end
+		def respond_to_missing?(name)
+			@object.respond_to?(name)
+		end
+	end
 end

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -1,196 +1,196 @@
 # frozen_string_literal: true
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
-  using Overrides::Symbol::Name
+	using Overrides::Symbol::Name
 end
 
 module Phlex
-  class Component
-    extend HTML
-    include Renderable
+	class Component
+		extend HTML
+		include Renderable
 
-    class << self
-      attr_accessor :rendered_at_least_once
-    end
+		class << self
+			attr_accessor :rendered_at_least_once
+				end
 
-    def call(buffer = +"", view_context: nil, parent: nil, &block)
-      raise "The same component instance shouldn't be rendered twice" if rendered?
+		def call(buffer = +"", view_context: nil, parent: nil, &block)
+			raise "The same component instance shouldn't be rendered twice" if rendered?
 
-      @_rendered = true
-      @_target = buffer
-      @_view_context = view_context
-      @_parent = parent
-      @output_buffer = self
+			@_rendered = true
+			@_target = buffer
+			@_view_context = view_context
+			@_parent = parent
+			@output_buffer = self
 
-      template(&block)
+			template(&block)
 
-      self.class.rendered_at_least_once ||= true
+			self.class.rendered_at_least_once ||= true
 
-      buffer
-    end
+			buffer
+		end
 
-    def rendered?
-      @_rendered ||= false
-    end
+		def rendered?
+			@_rendered ||= false
+		end
 
-    HTML::STANDARD_ELEMENTS.each do |element|
-      register_element(element)
-    end
+		HTML::STANDARD_ELEMENTS.each do |element|
+			register_element(element)
+		end
 
-    HTML::VOID_ELEMENTS.each do |element|
-      register_void_element(element)
-    end
+		HTML::VOID_ELEMENTS.each do |element|
+			register_void_element(element)
+		end
 
-    register_element :template_tag, tag: "template"
+		register_element :template_tag, tag: "template"
 
-    def content(&block)
-      return unless block_given?
+		def content(&block)
+			return unless block_given?
 
-      original_length = @_target.length
-      output = yield(self)
-      unchanged = (original_length == @_target.length)
+			original_length = @_target.length
+			output = yield(self)
+			unchanged = (original_length == @_target.length)
 
-      text(output) if unchanged
-      nil
-    end
+			text(output) if unchanged
+			nil
+		end
 
-    def text(content)
-      @_target << case content
-      when String then CGI.escape_html(content)
-      when Symbol then CGI.escape_html(content.name)
-      else CGI.escape_html(content.to_s)
-      end
+		def text(content)
+			@_target << case content
+			when String then CGI.escape_html(content)
+			when Symbol then CGI.escape_html(content.name)
+			else CGI.escape_html(content.to_s)
+			end
 
-      nil
-    end
+			nil
+		end
 
-    def whitespace
-      @_target << " "
-      nil
-    end
+		def whitespace
+			@_target << " "
+			nil
+		end
 
-    def doctype
-      @_target << HTML::DOCTYPE
-      nil
-    end
+		def doctype
+			@_target << HTML::DOCTYPE
+			nil
+		end
 
-    def raw(content)
-      @_target << content
-      nil
-    end
+		def raw(content)
+			@_target << content
+			nil
+		end
 
-    def html_safe?
-      true
-    end
+		def html_safe?
+			true
+		end
 
-    def safe_append=(value)
-      return unless value
+		def safe_append=(value)
+			return unless value
 
-      @_target << case value
-      when String then value
-      when Symbol then value.name
-      else value.to_s
-      end
-    end
+			@_target << case value
+			when String then value
+			when Symbol then value.name
+			else value.to_s
+			end
+		end
 
-    def append=(value)
-      return unless value
+		def append=(value)
+			return unless value
 
-      if value.html_safe?
-        self.safe_append = value
-      else
-        @_target << case value
-        when String then CGI.escape_html(value)
-        when Symbol then CGI.escape_html(value.name)
-        else CGI.escape_html(value.to_s)
-        end
-      end
-    end
+			if value.html_safe?
+				self.safe_append = value
+			else
+				@_target << case value
+				when String then CGI.escape_html(value)
+				when Symbol then CGI.escape_html(value.name)
+				else CGI.escape_html(value.to_s)
+				end
+			end
+		end
 
-    def capture(&block)
-      return unless block_given?
+		def capture(&block)
+			return unless block_given?
 
-      original_buffer = @_target
-      new_buffer = +""
-      @_target = new_buffer
+			original_buffer = @_target
+			new_buffer = +""
+			@_target = new_buffer
 
-      yield
+			yield
 
-      @_target = original_buffer
-      new_buffer.html_safe
-    end
+			@_target = original_buffer
+			new_buffer.html_safe
+		end
 
-    def classes(*tokens, **conditional_tokens)
-      { class: self.tokens(*tokens, **conditional_tokens) }
-    end
+		def classes(*tokens, **conditional_tokens)
+			{ class: self.tokens(*tokens, **conditional_tokens) }
+		end
 
-    def tokens(*tokens, **conditional_tokens)
-      conditional_tokens.each do |condition, token|
-        case condition
-        when Symbol then next unless send(condition)
-        when Proc then next unless condition.call
-        else raise ArgumentError,
-          "The class condition must be a Symbol or a Proc."
-        end
+		def tokens(*tokens, **conditional_tokens)
+			conditional_tokens.each do |condition, token|
+				case condition
+				when Symbol then next unless send(condition)
+				when Proc then next unless condition.call
+				else raise ArgumentError,
+										"The class condition must be a Symbol or a Proc."
+				end
 
-        case token
-        when Symbol then tokens << token.name
-        when String then tokens << token
-        when Array then tokens.concat(t)
-        else raise ArgumentError,
-          "Conditional classes must be Symbols, Strings, or Arrays of Symbols or Strings."
-        end
-      end
+				case token
+				when Symbol then tokens << token.name
+				when String then tokens << token
+				when Array then tokens.concat(t)
+				else raise ArgumentError,
+										"Conditional classes must be Symbols, Strings, or Arrays of Symbols or Strings."
+				end
+			end
 
-      tokens.compact.join(" ")
-    end
+			tokens.compact.join(" ")
+		end
 
-    def _attributes(attributes, buffer: +"")
-      if attributes[:href]&.start_with?(/\s*javascript/)
-        attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "")
-      end
+		def _attributes(attributes, buffer: +"")
+			if attributes[:href]&.start_with?(/\s*javascript/)
+				attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "")
+			end
 
-      _build_attributes(attributes, buffer: buffer)
+			_build_attributes(attributes, buffer: buffer)
 
-      unless self.class.rendered_at_least_once
-        Phlex::ATTRIBUTE_CACHE[attributes.hash] = buffer.freeze
-      end
+			unless self.class.rendered_at_least_once
+				Phlex::ATTRIBUTE_CACHE[attributes.hash] = buffer.freeze
+			end
 
-      buffer
-    end
+			buffer
+		end
 
-    def _build_attributes(attributes, buffer:)
-      attributes.each do |k, v|
-        next unless v
+		def _build_attributes(attributes, buffer:)
+			attributes.each do |k, v|
+				next unless v
 
-        name = case k
-        when String
-          k
-        when Symbol
-          k.name.tr("_", "-")
-        else
-          k.to_s
-        end
+				name = case k
+				when String
+					k
+				when Symbol
+					k.name.tr("_", "-")
+				else
+					k.to_s
+				end
 
-        if HTML::EVENT_ATTRIBUTES[name] || name.match?(/[<>&"']/)
-          raise ArgumentError, "Unsafe attribute name detected: #{k}."
-        end
+				if HTML::EVENT_ATTRIBUTES[name] || name.match?(/[<>&"']/)
+					raise ArgumentError, "Unsafe attribute name detected: #{k}."
+				end
 
-        case v
-        when true
-          buffer << " " << name
-        when String
-          buffer << " " << name << '="' << CGI.escape_html(v) << '"'
-        when Symbol
-          buffer << " " << name << '="' << CGI.escape_html(v.name) << '"'
-        when Hash
-          _build_attributes(v.transform_keys { "#{k}-#{_1.name.tr('_', '-')}" }, buffer: buffer)
-        else
-          buffer << " " << name << '="' << CGI.escape_html(v.to_s) << '"'
-        end
-      end
+				case v
+				when true
+					buffer << " " << name
+				when String
+					buffer << " " << name << '="' << CGI.escape_html(v) << '"'
+				when Symbol
+					buffer << " " << name << '="' << CGI.escape_html(v.name) << '"'
+				when Hash
+					_build_attributes(v.transform_keys { "#{k}-#{_1.name.tr('_', '-')}" }, buffer: buffer)
+				else
+					buffer << " " << name << '="' << CGI.escape_html(v.to_s) << '"'
+				end
+			end
 
-      buffer
-    end
-  end
+			buffer
+		end
+	end
 end

--- a/lib/phlex/configuration.rb
+++ b/lib/phlex/configuration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Phlex
-  class Configuration
-    # Config coming soon.
-  end
+	class Configuration
+		# Config coming soon.
+	end
 end

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -1,21 +1,21 @@
 # frozen_string_literal: true
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
-  using Overrides::Symbol::Name
+	using Overrides::Symbol::Name
 end
 
 module Phlex
-  module HTML
-    DOCTYPE = "<!DOCTYPE html>"
+	module HTML
+		DOCTYPE = "<!DOCTYPE html>"
 
-    STANDARD_ELEMENTS = %i[a abbr address article aside b bdi bdo blockquote body button caption cite code colgroup data datalist dd del details dfn dialog div dl dt em fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header html i iframe ins kbd label legend li main map mark menuitem meter nav noscript object ol optgroup option output p path picture pre progress q rp rt ruby s samp script section select slot small span strong style sub summary sup svg table tbody td textarea tfoot th thead time title tr u ul video wbr].freeze
+		STANDARD_ELEMENTS = %i[a abbr address article aside b bdi bdo blockquote body button caption cite code colgroup data datalist dd del details dfn dialog div dl dt em fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header html i iframe ins kbd label legend li main map mark menuitem meter nav noscript object ol optgroup option output p path picture pre progress q rp rt ruby s samp script section select slot small span strong style sub summary sup svg table tbody td textarea tfoot th thead time title tr u ul video wbr].freeze
 
-    VOID_ELEMENTS = %i[area embed img input link meta param source track col].freeze
+		VOID_ELEMENTS = %i[area embed img input link meta param source track col].freeze
 
-    EVENT_ATTRIBUTES = %w[onabort onafterprint onbeforeprint onbeforeunload onblur oncanplay oncanplaythrough onchange onclick oncontextmenu oncopy oncuechange oncut ondblclick ondrag ondragend ondragenter ondragleave ondragover ondragstart ondrop ondurationchange onemptied onended onerror onerror onfocus onhashchange oninput oninvalid onkeydown onkeypress onkeyup onload onloadeddata onloadedmetadata onloadstart onmessage onmousedown onmousemove onmouseout onmouseover onmouseup onmousewheel onoffline ononline onpagehide onpageshow onpaste onpause onplay onplaying onpopstate onprogress onratechange onreset onresize onscroll onsearch onseeked onseeking onselect onstalled onstorage onsubmit onsuspend ontimeupdate ontoggle onunload onvolumechange onwaiting onwheel].to_h { [_1, true] }.freeze
+		EVENT_ATTRIBUTES = %w[onabort onafterprint onbeforeprint onbeforeunload onblur oncanplay oncanplaythrough onchange onclick oncontextmenu oncopy oncuechange oncut ondblclick ondrag ondragend ondragenter ondragleave ondragover ondragstart ondrop ondurationchange onemptied onended onerror onerror onfocus onhashchange oninput oninvalid onkeydown onkeypress onkeyup onload onloadeddata onloadedmetadata onloadstart onmessage onmousedown onmousemove onmouseout onmouseover onmouseup onmousewheel onoffline ononline onpagehide onpageshow onpaste onpause onplay onplaying onpopstate onprogress onratechange onreset onresize onscroll onsearch onseeked onseeking onselect onstalled onstorage onsubmit onsuspend ontimeupdate ontoggle onunload onvolumechange onwaiting onwheel].to_h { [_1, true] }.freeze
 
-    def register_element(element, tag: element.name.tr("_", "-"))
-      class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+		def register_element(element, tag: element.name.tr("_", "-"))
+			class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
         # frozen_string_literal: true
 
         def #{element}(content = nil, **attributes, &block)
@@ -50,11 +50,11 @@ module Phlex
 
           nil
         end
-      RUBY
-    end
+						RUBY
+		end
 
-    def register_void_element(element, tag: element.name.tr("_", "-"))
-      class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+		def register_void_element(element, tag: element.name.tr("_", "-"))
+			class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
         # frozen_string_literal: true
 
         def #{element}(**attributes)
@@ -66,7 +66,7 @@ module Phlex
 
           nil
         end
-      RUBY
-    end
-  end
+						RUBY
+		end
+	end
 end

--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Phlex
-  module Rails
-  end
+	module Rails
+	end
 end
 
 Phlex::Component.include(Phlex::Rails::TagHelpers)

--- a/lib/phlex/rails/tag_helpers.rb
+++ b/lib/phlex/rails/tag_helpers.rb
@@ -1,29 +1,29 @@
 # frozen_string_literal: true
 
 module Phlex
-  module Rails
-    module TagHelpers
-      def form_with(*args, **kwargs, &block)
-        raw @_view_context.form_with(*args, **kwargs) { |form|
-          capture do
-            yield(
-              Phlex::Buffered.new(form, buffer: @_target)
-            )
-          end
-        }
-      end
+	module Rails
+		module TagHelpers
+			def form_with(*args, **kwargs, &block)
+				raw @_view_context.form_with(*args, **kwargs) { |form|
+									capture do
+										yield(
+														Phlex::Buffered.new(form, buffer: @_target)
+												)
+									end
+								}
+			end
 
-      def csp_meta_tag
-        if (output = @_view_context.csp_meta_tag)
-          @_target << output
-        end
-      end
+			def csp_meta_tag
+				if (output = @_view_context.csp_meta_tag)
+					@_target << output
+				end
+			end
 
-      def csrf_meta_tags
-        if (output = @_view_context.csrf_meta_tags)
-          @_target << output
-        end
-      end
-    end
-  end
+			def csrf_meta_tags
+				if (output = @_view_context.csrf_meta_tags)
+					@_target << output
+				end
+			end
+		end
+	end
 end

--- a/lib/phlex/renderable.rb
+++ b/lib/phlex/renderable.rb
@@ -1,41 +1,41 @@
 # frozen_string_literal: true
 
 module Phlex
-  module Renderable
-    def render(renderable, *args, **kwargs, &block)
-      if renderable.is_a?(Component)
-        if block_given? && !block.binding.receiver.is_a?(Phlex::Block)
-          block = Phlex::Block.new(self, &block)
-        end
+	module Renderable
+		def render(renderable, *args, **kwargs, &block)
+			if renderable.is_a?(Component)
+				if block_given? && !block.binding.receiver.is_a?(Phlex::Block)
+					block = Phlex::Block.new(self, &block)
+				end
 
-        renderable.call(@_target, view_context: @_view_context, parent: self, &block)
-      elsif renderable.is_a?(Class) && renderable < Component
-        raise ArgumentError, "You tried to render the Phlex component class: #{renderable.name} but you probably meant to render an instance of that class instead."
-      else
-        @_target << @_view_context.render(renderable, *args, **kwargs, &block)
-      end
+				renderable.call(@_target, view_context: @_view_context, parent: self, &block)
+			elsif renderable.is_a?(Class) && renderable < Component
+				raise ArgumentError, "You tried to render the Phlex component class: #{renderable.name} but you probably meant to render an instance of that class instead."
+			else
+				@_target << @_view_context.render(renderable, *args, **kwargs, &block)
+			end
 
-      nil
-    end
+			nil
+		end
 
-    def render_in(view_context, &block)
-      if block_given?
-        call(view_context: view_context) do |*args, **kwargs|
-          view_context.with_output_buffer(self) do
-            original_length = @_target.length
-            output = yield(*args, **kwargs)
-            unchanged = (original_length == @_target.length)
+		def render_in(view_context, &block)
+			if block_given?
+				call(view_context: view_context) do |*args, **kwargs|
+					view_context.with_output_buffer(self) do
+						original_length = @_target.length
+						output = yield(*args, **kwargs)
+						unchanged = (original_length == @_target.length)
 
-            text(output) if unchanged && output.is_a?(String)
-          end
-        end.html_safe
-      else
-        call(view_context: view_context).html_safe
-      end
-    end
+						text(output) if unchanged && output.is_a?(String)
+					end
+				end.html_safe
+			else
+				call(view_context: view_context).html_safe
+			end
+		end
 
-    def format
-      :html
-    end
-  end
+		def format
+			:html
+		end
+	end
 end

--- a/lib/phlex/version.rb
+++ b/lib/phlex/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Phlex
-  VERSION = "0.2.2"
+	VERSION = "0.2.2"
 end

--- a/phlex.gemspec
+++ b/phlex.gemspec
@@ -3,39 +3,39 @@
 require_relative "lib/phlex/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "phlex"
-  spec.version = Phlex::VERSION
-  spec.authors = ["Joel Drapper"]
-  spec.email = ["joel@drapper.me"]
+	spec.name = "phlex"
+	spec.version = Phlex::VERSION
+	spec.authors = ["Joel Drapper"]
+	spec.email = ["joel@drapper.me"]
 
-  spec.summary = "A framework for building view components with a Ruby DSL."
-  spec.description = "A high-performance view component framework optimised for developer happiness."
-  spec.homepage = "https://www.phlex.fun"
-  spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7"
+	spec.summary = "A framework for building view components with a Ruby DSL."
+	spec.description = "A high-performance view component framework optimised for developer happiness."
+	spec.homepage = "https://www.phlex.fun"
+	spec.license = "MIT"
+	spec.required_ruby_version = ">= 2.7"
 
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/joeldrapper/phlex"
-  spec.metadata["changelog_uri"] = "https://github.com/joeldrapper/phlex/releases"
-  spec.metadata["funding_uri"] = "https://github.com/sponsors/joeldrapper"
+	spec.metadata["homepage_uri"] = spec.homepage
+	spec.metadata["source_code_uri"] = "https://github.com/joeldrapper/phlex"
+	spec.metadata["changelog_uri"] = "https://github.com/joeldrapper/phlex/releases"
+	spec.metadata["funding_uri"] = "https://github.com/sponsors/joeldrapper"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
-    end
-  end
-  spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+	# Specify which files should be added to the gem when it is released.
+	# The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+	spec.files = Dir.chdir(File.expand_path(__dir__)) do
+		`git ls-files -z`.split("\x0").reject do |f|
+			(f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+		end
+	end
+	spec.bindir = "exe"
+	spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+	spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+	# Uncomment to register a new dependency of your gem
+	# spec.add_dependency "example-gem", "~> 1.0"
 
-  spec.add_dependency "zeitwerk", "~> 2.6"
+	spec.add_dependency "zeitwerk", "~> 2.6"
 
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
-  spec.metadata["rubygems_mfa_required"] = "true"
+	# For more information and examples about making a new gem, check out our
+	# guide at: https://bundler.io/guides/creating_gem.html
+	spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/test/phlex/component/attributes.rb
+++ b/test/phlex/component/attributes.rb
@@ -3,39 +3,39 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "hash attributes" do
-    component do
-      def template
-        div data: { name: { first_name: "Joel" } }
-      end
-    end
+	with "hash attributes" do
+		component do
+			def template
+				div data: { name: { first_name: "Joel" } }
+			end
+		end
 
-    it "flattens the attributes" do
-      expect(output).to be == %(<div data-name-first-name="Joel"></div>)
-    end
-  end
+		it "flattens the attributes" do
+			expect(output).to be == %(<div data-name-first-name="Joel"></div>)
+		end
+	end
 
-  if RUBY_ENGINE == "ruby"
-    with "unique tag attributes" do
-      component do
-        def template
-          div class: SecureRandom.hex
-        end
-      end
+	if RUBY_ENGINE == "ruby"
+		with "unique tag attributes" do
+			component do
+				def template
+					div class: SecureRandom.hex
+				end
+			end
 
-      let :report do
-        component.new.call
+			let :report do
+				component.new.call
 
-        MemoryProfiler.report do
-          2.times { component.new.call }
-        end
-      end
+				MemoryProfiler.report do
+					2.times { component.new.call }
+				end
+			end
 
-      it "doesn't leak memory" do
-        expect(report.total_retained).to be == 0
-      end
-    end
-  end
+			it "doesn't leak memory" do
+				expect(report.total_retained).to be == 0
+			end
+		end
+	end
 end

--- a/test/phlex/component/call.rb
+++ b/test/phlex/component/call.rb
@@ -3,26 +3,26 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  component do
-    def template
-      text "Hi"
-    end
-  end
+	component do
+		def template
+			text "Hi"
+		end
+	end
 
-  with "#call" do
-    it "renders the component" do
-      expect(example.call).to be == "Hi"
-    end
+	with "#call" do
+		it "renders the component" do
+			expect(example.call).to be == "Hi"
+		end
 
-    with "a spent component" do
-      let(:example) { component.new.tap(&:call) }
+		with "a spent component" do
+			let(:example) { component.new.tap(&:call) }
 
-      it "raises an ArgumentError" do
-        expect { example.call }.to raise_exception RuntimeError,
-          message: "The same component instance shouldn't be rendered twice"
-      end
-    end
-  end
+			it "raises an ArgumentError" do
+				expect { example.call }.to raise_exception RuntimeError,
+										message: "The same component instance shouldn't be rendered twice"
+			end
+		end
+	end
 end

--- a/test/phlex/component/content.rb
+++ b/test/phlex/component/content.rb
@@ -3,19 +3,19 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "content" do
-    component do
-      def template(&block)
-        div do
-          content(&block)
-        end
-      end
-    end
+	with "content" do
+		component do
+			def template(&block)
+				div do
+					content(&block)
+				end
+			end
+		end
 
-    it "renders text content" do
-      expect(example.call { "Hi" }).to be == "<div>Hi</div>"
-    end
-  end
+		it "renders text content" do
+			expect(example.call { "Hi" }).to be == "<div>Hi</div>"
+		end
+	end
 end

--- a/test/phlex/component/custom_elements.rb
+++ b/test/phlex/component/custom_elements.rb
@@ -3,24 +3,24 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "custom elements" do
-    component do
-      register_element :trix_editor
-      register_element :trix_toolbar
+	with "custom elements" do
+		component do
+			register_element :trix_editor
+			register_element :trix_toolbar
 
-      def template
-        div do
-          trix_toolbar
-          trix_editor "Hello"
-        end
-      end
-    end
+			def template
+				div do
+					trix_toolbar
+					trix_editor "Hello"
+				end
+			end
+		end
 
-    it "produces the correct markup" do
-      expect(output).to be ==
-        "<div><trix-toolbar></trix-toolbar><trix-editor>Hello</trix-editor></div>"
-    end
-  end
+		it "produces the correct markup" do
+			expect(output).to be ==
+								"<div><trix-toolbar></trix-toolbar><trix-editor>Hello</trix-editor></div>"
+		end
+	end
 end

--- a/test/phlex/component/doctype.rb
+++ b/test/phlex/component/doctype.rb
@@ -3,19 +3,19 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "a doctype" do
-    component do
-      def template
-        html do
-          head { doctype }
-        end
-      end
-    end
+	with "a doctype" do
+		component do
+			def template
+				html do
+					head { doctype }
+				end
+			end
+		end
 
-    it "produces the correct output" do
-      expect(output).to be == "<html><head><!DOCTYPE html></head></html>"
-    end
-  end
+		it "produces the correct output" do
+			expect(output).to be == "<html><head><!DOCTYPE html></head></html>"
+		end
+	end
 end

--- a/test/phlex/component/naughty_business.rb
+++ b/test/phlex/component/naughty_business.rb
@@ -3,76 +3,76 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "naughty text" do
-    component do
-      def template
-        text %("><script type="text/javascript" src="bad_script.js"></script>)
-      end
-    end
+	with "naughty text" do
+		component do
+			def template
+				text %("><script type="text/javascript" src="bad_script.js"></script>)
+			end
+		end
 
-    it "escapes the content" do
-      expect(output).to be == "&quot;&gt;&lt;script type=&quot;text/javascript&quot; src=&quot;bad_script.js&quot;&gt;&lt;/script&gt;"
-    end
-  end
+		it "escapes the content" do
+			expect(output).to be == "&quot;&gt;&lt;script type=&quot;text/javascript&quot; src=&quot;bad_script.js&quot;&gt;&lt;/script&gt;"
+		end
+	end
 
-  with "naughty tag attribute values" do
-    component do
-      def template
-        article id: %("><script type="text/javascript" src="bad_script.js"></script>)
-      end
-    end
+	with "naughty tag attribute values" do
+		component do
+			def template
+				article id: %("><script type="text/javascript" src="bad_script.js"></script>)
+			end
+		end
 
-    it "escapes the attributes" do
-      expect(output).to be == %(<article id="&quot;&gt;&lt;script type=&quot;text/javascript&quot; src=&quot;bad_script.js&quot;&gt;&lt;/script&gt;"></article>)
-    end
-  end
+		it "escapes the attributes" do
+			expect(output).to be == %(<article id="&quot;&gt;&lt;script type=&quot;text/javascript&quot; src=&quot;bad_script.js&quot;&gt;&lt;/script&gt;"></article>)
+		end
+	end
 
-  with "naughty javascript link protocol in href" do
-    component do
-      def template
-        a "naughty link", href: "javascript:javascript:alert(1)"
-      end
-    end
+	with "naughty javascript link protocol in href" do
+		component do
+			def template
+				a "naughty link", href: "javascript:javascript:alert(1)"
+			end
+		end
 
-    it "strips the javascript protocol" do
-      expect(output).to be == %{<a href="alert(1)">naughty link</a>}
-    end
-  end
+		it "strips the javascript protocol" do
+			expect(output).to be == %{<a href="alert(1)">naughty link</a>}
+		end
+	end
 
-  Phlex::HTML::EVENT_ATTRIBUTES.each_key do |event_attribute|
-    with "with naughty #{event_attribute} attribute" do
-      naughty_attributes = { event_attribute => "alert(1);" }
+	Phlex::HTML::EVENT_ATTRIBUTES.each_key do |event_attribute|
+		with "with naughty #{event_attribute} attribute" do
+			naughty_attributes = { event_attribute => "alert(1);" }
 
-      component do
-        define_method :template do
-          send(:div, **naughty_attributes)
-        end
-      end
+			component do
+				define_method :template do
+					send(:div, **naughty_attributes)
+				end
+			end
 
-      it "raises an ArgumentError" do
-        expect { output }.to raise_exception ArgumentError,
-          message: "Unsafe attribute name detected: #{event_attribute}."
-      end
-    end
-  end
+			it "raises an ArgumentError" do
+				expect { output }.to raise_exception ArgumentError,
+										message: "Unsafe attribute name detected: #{event_attribute}."
+			end
+		end
+	end
 
-  %w[< > & " '].each do |naughty_character|
-    with "naughty attribute name containing #{naughty_character}" do
-      naughty_attribute = "abc#{naughty_character}123"
-      naughty_attributes = { naughty_attribute => "alert(1);" }
+	%w[< > & " '].each do |naughty_character|
+		with "naughty attribute name containing #{naughty_character}" do
+			naughty_attribute = "abc#{naughty_character}123"
+			naughty_attributes = { naughty_attribute => "alert(1);" }
 
-      component do
-        define_method :template do
-          send(:div, **naughty_attributes)
-        end
-      end
+			component do
+				define_method :template do
+					send(:div, **naughty_attributes)
+				end
+			end
 
-      it "raises an ArgumentError" do
-        expect { output }.to raise_exception ArgumentError,
-          message: "Unsafe attribute name detected: #{naughty_attribute}."
-      end
-    end
-  end
+			it "raises an ArgumentError" do
+				expect { output }.to raise_exception ArgumentError,
+										message: "Unsafe attribute name detected: #{naughty_attribute}."
+			end
+		end
+	end
 end

--- a/test/phlex/component/numbers.rb
+++ b/test/phlex/component/numbers.rb
@@ -3,36 +3,36 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "numbers" do
-    component do
-      def template
-        span 1
-        span 2.0
-      end
-    end
+	with "numbers" do
+		component do
+			def template
+				span 1
+				span 2.0
+			end
+		end
 
-    it "produces the correct output" do
-      expect(output).to be == "<span>1</span><span>2.0</span>"
-    end
-  end
+		it "produces the correct output" do
+			expect(output).to be == "<span>1</span><span>2.0</span>"
+		end
+	end
 
-  with "numbers in block" do
-    component do
-      def template
-        span do
-          1
-        end
+	with "numbers in block" do
+		component do
+			def template
+				span do
+					1
+				end
 
-        span do
-          2.0
-        end
-      end
-    end
+				span do
+					2.0
+				end
+			end
+		end
 
-    it "produces the correct output" do
-      expect(output).to be == "<span>1</span><span>2.0</span>"
-    end
-  end
+		it "produces the correct output" do
+			expect(output).to be == "<span>1</span><span>2.0</span>"
+		end
+	end
 end

--- a/test/phlex/component/raw.rb
+++ b/test/phlex/component/raw.rb
@@ -3,17 +3,17 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "raw content" do
-    component do
-      def template
-        raw %(<h1 class="test">Hello</h1>)
-      end
-    end
+	with "raw content" do
+		component do
+			def template
+				raw %(<h1 class="test">Hello</h1>)
+			end
+		end
 
-    it "renders produces the correct output" do
-      expect(output).to be == %(<h1 class="test">Hello</h1>)
-    end
-  end
+		it "renders produces the correct output" do
+			expect(output).to be == %(<h1 class="test">Hello</h1>)
+		end
+	end
 end

--- a/test/phlex/component/renderable/format.rb
+++ b/test/phlex/component/renderable/format.rb
@@ -3,13 +3,13 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  component
+	component
 
-  with "format" do
-    it "returns :html" do
-      expect(example.format).to be == :html
-    end
-  end
+	with "format" do
+		it "returns :html" do
+			expect(example.format).to be == :html
+		end
+	end
 end

--- a/test/phlex/component/renderable/render.rb
+++ b/test/phlex/component/renderable/render.rb
@@ -5,54 +5,54 @@ require "test_helper"
 Example = Class.new(Phlex::Component)
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "#render" do
-    with "a component class" do
-      component do
-        def template
-          render Example
-        end
-      end
+	with "#render" do
+		with "a component class" do
+			component do
+				def template
+					render Example
+				end
+			end
 
-      it "raises an ArgumentError" do
-        expect { output }.to raise_exception ArgumentError, message:
-          "You tried to render the Phlex component class: #{Example.name} but you probably meant to render an instance of that class instead."
-      end
-    end
+			it "raises an ArgumentError" do
+				expect { output }.to raise_exception ArgumentError, message:
+										"You tried to render the Phlex component class: #{Example.name} but you probably meant to render an instance of that class instead."
+			end
+		end
 
-    with "another component" do
-      other_component = Class.new Phlex::Component do
-        def template(&block)
-          div(&block)
-        end
-      end
+		with "another component" do
+			other_component = Class.new Phlex::Component do
+				def template(&block)
+					div(&block)
+				end
+			end
 
-      with "markup" do
-        component do
-          define_method :template do
-            render(other_component.new) do
-              h1 "Hi!"
-            end
-          end
-        end
+			with "markup" do
+				component do
+					define_method :template do
+						render(other_component.new) do
+							h1 "Hi!"
+						end
+					end
+				end
 
-        it "renders the other component" do
-          expect(output).to be == "<div><h1>Hi!</h1></div>"
-        end
-      end
+				it "renders the other component" do
+					expect(output).to be == "<div><h1>Hi!</h1></div>"
+				end
+			end
 
-      with "text" do
-        component do
-          define_method :template do
-            render(other_component.new) { "Hello world!" }
-          end
-        end
+			with "text" do
+				component do
+					define_method :template do
+						render(other_component.new) { "Hello world!" }
+					end
+				end
 
-        it "renders the other component" do
-          expect(output).to be == "<div>Hello world!</div>"
-        end
-      end
-    end
-  end
+				it "renders the other component" do
+					expect(output).to be == "<div>Hello world!</div>"
+				end
+			end
+		end
+	end
 end

--- a/test/phlex/component/tags.rb
+++ b/test/phlex/component/tags.rb
@@ -3,57 +3,57 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  Phlex::HTML::STANDARD_ELEMENTS.each do |element|
-    with "<#{element}> with text content and attributes" do
-      component do
-        define_method :template do
-          send(element, "content", class: "class", id: "id", disabled: true, selected: false)
-        end
-      end
+	Phlex::HTML::STANDARD_ELEMENTS.each do |element|
+		with "<#{element}> with text content and attributes" do
+			component do
+				define_method :template do
+					send(element, "content", class: "class", id: "id", disabled: true, selected: false)
+				end
+			end
 
-      it "produces the correct output" do
-        expect(output).to be == %(<#{element} class="class" id="id" disabled>content</#{element}>)
-      end
-    end
+			it "produces the correct output" do
+				expect(output).to be == %(<#{element} class="class" id="id" disabled>content</#{element}>)
+			end
+		end
 
-    with "<#{element}> with block content and attributes" do
-      component do
-        define_method :template do
-          send(element, class: "class", id: "id", disabled: true, selected: false) { h1 "Hello" }
-        end
-      end
+		with "<#{element}> with block content and attributes" do
+			component do
+				define_method :template do
+					send(element, class: "class", id: "id", disabled: true, selected: false) { h1 "Hello" }
+				end
+			end
 
-      it "produces the correct output" do
-        expect(output).to be == %(<#{element} class="class" id="id" disabled><h1>Hello</h1></#{element}>)
-      end
-    end
+			it "produces the correct output" do
+				expect(output).to be == %(<#{element} class="class" id="id" disabled><h1>Hello</h1></#{element}>)
+			end
+		end
 
-    with "<#{element}> with block text content and attributes" do
-      component do
-        define_method :template do
-          send(element, class: "class", id: "id", disabled: true, selected: false) { "content" }
-        end
-      end
+		with "<#{element}> with block text content and attributes" do
+			component do
+				define_method :template do
+					send(element, class: "class", id: "id", disabled: true, selected: false) { "content" }
+				end
+			end
 
-      it "produces the correct output" do
-        expect(output).to be == %(<#{element} class="class" id="id" disabled>content</#{element}>)
-      end
-    end
-  end
+			it "produces the correct output" do
+				expect(output).to be == %(<#{element} class="class" id="id" disabled>content</#{element}>)
+			end
+		end
+	end
 
-  Phlex::HTML::VOID_ELEMENTS.each do |element|
-    with "<#{element}> with attributes" do
-      component do
-        define_method :template do
-          send(element, class: "class", id: "id", disabled: true, selected: false)
-        end
-      end
+	Phlex::HTML::VOID_ELEMENTS.each do |element|
+		with "<#{element}> with attributes" do
+			component do
+				define_method :template do
+					send(element, class: "class", id: "id", disabled: true, selected: false)
+				end
+			end
 
-      it "produces the correct output" do
-        expect(output).to be == %(<#{element} class="class" id="id" disabled />)
-      end
-    end
-  end
+			it "produces the correct output" do
+				expect(output).to be == %(<#{element} class="class" id="id" disabled />)
+			end
+		end
+	end
 end

--- a/test/phlex/component/text.rb
+++ b/test/phlex/component/text.rb
@@ -3,41 +3,41 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "text" do
-    component do
-      def template
-        text "Hi"
-      end
-    end
+	with "text" do
+		component do
+			def template
+				text "Hi"
+			end
+		end
 
-    it "produces the correct output" do
-      expect(output).to be == "Hi"
-    end
-  end
+		it "produces the correct output" do
+			expect(output).to be == "Hi"
+		end
+	end
 
-  with "int as text" do
-    component do
-      def template
-        text 1
-      end
-    end
+	with "int as text" do
+		component do
+			def template
+				text 1
+			end
+		end
 
-    it "produces the correct output" do
-      expect(output).to be == "1"
-    end
-  end
+		it "produces the correct output" do
+			expect(output).to be == "1"
+		end
+	end
 
-  with "float as text" do
-    component do
-      def template
-        text 2.0
-      end
-    end
+	with "float as text" do
+		component do
+			def template
+				text 2.0
+			end
+		end
 
-    it "produces the correct output" do
-      expect(output).to be == "2.0"
-    end
-  end
+		it "produces the correct output" do
+			expect(output).to be == "2.0"
+		end
+	end
 end

--- a/test/phlex/component/tokens.rb
+++ b/test/phlex/component/tokens.rb
@@ -3,43 +3,43 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "conditional classes" do
-    with "symbol conditionals" do
-      component do
-        def template
-          a "Home", href: "/", **classes("a", "b", "c", active?: "active", primary?: "primary")
-        end
+	with "conditional classes" do
+		with "symbol conditionals" do
+			component do
+				def template
+					a "Home", href: "/", **classes("a", "b", "c", active?: "active", primary?: "primary")
+				end
 
-        def active?
-          false
-        end
+				def active?
+					false
+				end
 
-        def primary?
-          true
-        end
-      end
+				def primary?
+					true
+				end
+			end
 
-      it "works" do
-        expect(output).to be ==
-          %(<a href="/" class="a b c primary">Home</a>)
-      end
-    end
+			it "works" do
+				expect(output).to be ==
+										%(<a href="/" class="a b c primary">Home</a>)
+			end
+		end
 
-    with "proc conditionals" do
-      component do
-        def template
-          a "Home", href: "/", **classes("a", "b", "c",
-            -> { true } => "true",
-            -> { false } => "false")
-        end
-      end
+		with "proc conditionals" do
+			component do
+				def template
+					a "Home", href: "/", **classes("a", "b", "c",
+												-> { true } => "true",
+												-> { false } => "false")
+				end
+			end
 
-      it "works" do
-        expect(output).to be ==
-          %(<a href="/" class="a b c true">Home</a>)
-      end
-    end
-  end
+			it "works" do
+				expect(output).to be ==
+										%(<a href="/" class="a b c true">Home</a>)
+			end
+		end
+	end
 end

--- a/test/phlex/component/whitespace.rb
+++ b/test/phlex/component/whitespace.rb
@@ -3,19 +3,19 @@
 require "test_helper"
 
 describe Phlex::Component do
-  extend ComponentHelper
+	extend ComponentHelper
 
-  with "whitespace" do
-    component do
-      def template
-        a "Home"
-        whitespace
-        a "About"
-      end
-    end
+	with "whitespace" do
+		component do
+			def template
+				a "Home"
+				whitespace
+				a "About"
+			end
+		end
 
-    it "produces the correct output" do
-      expect(output).to be == "<a>Home</a> <a>About</a>"
-    end
-  end
+		it "produces the correct output" do
+			expect(output).to be == "<a>Home</a> <a>About</a>"
+		end
+	end
 end

--- a/test/phlex/rails.rb
+++ b/test/phlex/rails.rb
@@ -3,12 +3,12 @@
 require "test_helper"
 
 describe Phlex::Component do
-  with "rendered in an ERB view" do
-    let(:output) { ArticlesController.render "index" }
+	with "rendered in an ERB view" do
+		let(:output) { ArticlesController.render "index" }
 
-    it "renders the correct output" do
-      expect(output).to be ==
-        %(<p>Before</p>\n\n<h1>Hello World!</h1>\n\n<article class=\"drop-shadow p-5 rounded\">\n  <p>Start Card A</p>\n  <h3 class=\"font-bold\">Hello from A</h3>\n  <article class=\"drop-shadow p-5 rounded\">\n    <p>Start Card B</p>\n    <h3 class=\"font-bold\">Hello from B</h3>\n    <p>End Card B</p>\n</article>  <p>End Card A</p>\n</article>)
-    end
-  end
+		it "renders the correct output" do
+			expect(output).to be ==
+								%(<p>Before</p>\n\n<h1>Hello World!</h1>\n\n<article class=\"drop-shadow p-5 rounded\">\n  <p>Start Card A</p>\n  <h3 class=\"font-bold\">Hello from A</h3>\n  <article class=\"drop-shadow p-5 rounded\">\n    <p>Start Card B</p>\n    <h3 class=\"font-bold\">Hello from B</h3>\n    <p>End Card B</p>\n</article>  <p>End Card A</p>\n</article>)
+		end
+	end
 end

--- a/test/phlex/rails/form_with.rb
+++ b/test/phlex/rails/form_with.rb
@@ -4,12 +4,12 @@ require "test_helper"
 require "phlex/rails"
 
 describe Phlex::Component do
-  let(:output) { ArticlesController.render "new" }
+	let(:output) { ArticlesController.render "new" }
 
-  with "form_with" do
-    it "renders the form" do
-      expect(output).to be ==
-        %(<form action="test" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><input type="text" name="name" /></form>\n)
-    end
-  end
+	with "form_with" do
+		it "renders the form" do
+			expect(output).to be ==
+								%(<form action="test" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" autocomplete="off" /><input type="text" name="name" /></form>\n)
+		end
+	end
 end


### PR DESCRIPTION
Switching from spaces to tabs for accessibility. This code should be accessible to everyone.

To make this easier, I’ve updated the RuboCop config, `rubocop -A` should autocorrect any spaces to tabs. Additionally, I’ve added a `.editorconfig` with 2-width tabs by default.