### PR TITLE
Add `comment` to support HTML comments

### DIFF
--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -70,7 +70,7 @@ module Phlex
 		end
 
 		def comment(content = "")
-			@_target << "<!-- " << content.to_s << " -->"
+			@_target << "<!-- " << CGI.escape_html(content.to_s) << " -->"
 			nil
 		end
 

--- a/lib/phlex/component.rb
+++ b/lib/phlex/component.rb
@@ -11,7 +11,7 @@ module Phlex
 
 		class << self
 			attr_accessor :rendered_at_least_once
-				end
+		end
 
 		def call(buffer = +"", view_context: nil, parent: nil, &block)
 			raise "The same component instance shouldn't be rendered twice" if rendered?
@@ -66,6 +66,11 @@ module Phlex
 
 		def whitespace
 			@_target << " "
+			nil
+		end
+
+		def comment(content = "")
+			@_target << "<!-- " << content.to_s << " -->"
 			nil
 		end
 

--- a/test/phlex/component/comment.rb
+++ b/test/phlex/component/comment.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Phlex::Component do
+	extend ComponentHelper
+
+	with "simple comment" do
+		component do
+			def template
+				comment "This is an HTML comment"
+			end
+		end
+
+		it "produces the correct output" do
+			expect(output).to be == "<!-- This is an HTML comment -->"
+		end
+	end
+
+	with "empty comment" do
+		component do
+			def template
+				comment
+			end
+		end
+
+		it "produces the correct output" do
+			expect(output).to be == "<!--  -->"
+		end
+	end
+
+	with "number comment" do
+		component do
+			def template
+				comment 1
+			end
+		end
+
+		it "produces the correct output" do
+			expect(output).to be == "<!-- 1 -->"
+		end
+	end
+end

--- a/test/phlex/component/comment.rb
+++ b/test/phlex/component/comment.rb
@@ -40,4 +40,16 @@ describe Phlex::Component do
 			expect(output).to be == "<!-- 1 -->"
 		end
 	end
+
+	with "escaped comment" do
+		component do
+			def template
+				comment "<b>Important</b>"
+			end
+		end
+
+		it "produces the correct output" do
+			expect(output).to be == "<!-- &lt;b&gt;Important&lt;/b&gt; -->"
+		end
+	end
 end


### PR DESCRIPTION
Sometimes it can also be useful to add comments to your generated HTML. 

That's why this Pull Request introduces a `comment` method to `Phlex::Component` so that you can create HTML comments using the Phlex DSL.