### PR TITLE
fix: autoloading of rails engines

### DIFF
--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -25,10 +25,9 @@ module Phlex
 	end
 end
 
-
 begin
-  require "rails"
-  require "phlex/engine"
+	require "rails"
+	require "phlex/engine"
 rescue LoadError
-  # Rails isnt in this env, dont load the engine.
+	# Rails isnt in this env, dont load the engine.
 end

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -29,5 +29,5 @@ begin
 	require "rails"
 	require "phlex/engine"
 rescue LoadError
-	# Rails isnt in this env, dont load the engine.
+	# Rails isn't in this env, don't load the engine.
 end

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -25,6 +25,4 @@ module Phlex
 	end
 end
 
-if defined?(Rails::Engine)
-	require "rails"
-end
+require "phlex/engine"

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -25,4 +25,10 @@ module Phlex
 	end
 end
 
-require "phlex/engine"
+
+begin
+  require "rails"
+  require "phlex/engine"
+rescue LoadError
+  # Rails isnt in this env, dont load the engine.
+end

--- a/lib/phlex/engine.rb
+++ b/lib/phlex/engine.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails/engine"
+
+module Phlex
+	class Engine < ::Rails::Engine
+		initializer "phlex.tag_helpers" do
+      Phlex::Component.include(Phlex::Rails::TagHelpers)
+		end
+	end
+end

--- a/lib/phlex/engine.rb
+++ b/lib/phlex/engine.rb
@@ -5,7 +5,7 @@ require "rails/engine"
 module Phlex
 	class Engine < ::Rails::Engine
 		initializer "phlex.tag_helpers" do
-      Phlex::Component.include(Phlex::Rails::TagHelpers)
+			Phlex::Component.include(Phlex::Rails::TagHelpers)
 		end
 	end
 end

--- a/lib/phlex/rails.rb
+++ b/lib/phlex/rails.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Phlex
-	module Rails
-	end
-end
-
-Phlex::Component.include(Phlex::Rails::TagHelpers)

--- a/test/phlex/rails/form_with.rb
+++ b/test/phlex/rails/form_with.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "phlex/rails"
 
 describe Phlex::Component do
 	let(:output) { ArticlesController.render "new" }


### PR DESCRIPTION
This more closely follows the Rails convention for Engines. 

The only thing I'm not sure about is what happens if the Rails engine is loaded when the user doesn't have Rails so I added a "LoadError" check.