### PR TITLE
Support chain appends in Compiler formatter

### DIFF
--- a/test/phlex/compiler/formatter.rb
+++ b/test/phlex/compiler/formatter.rb
@@ -8,31 +8,63 @@ describe Phlex::Compiler::Formatter do
 
 	with "append block" do
 		it "buffers an append string" do
-			formatter.append do |f|
-				f.text "a"
-				f.text "b"
-				f.text "c"
-			end
+			formatter.append { _1.text "a" }
+			formatter.append { _1.text "b" }
+			formatter.append { _1.text "c" }
 
 			expect(output).to be == %(@_target << \"abc")
 		end
 
 		it "allows for breaks" do
-			formatter.append do |f|
-				f.text "a"
-				f.text "b"
-			end
+			formatter.append { _1.text "a" }
 
 			formatter.breakable(force: true)
-			formatter.text "c"
+			formatter.text "b"
 			formatter.breakable(force: true)
 
-			formatter.append do |f|
-				f.text "d"
-				f.text "e"
-			end
+			formatter.append { _1.text "c" }
 
-			expect(output).to be == %(@_target << "ab"\nc\n@_target << "de")
+			expect(output).to be == %(@_target << "a"\nb\n@_target << "c")
+		end
+	end
+
+	with "chain append" do
+		it "chains the appends" do
+			formatter.chain_append { _1.text "a" }
+			formatter.chain_append { _1.text "b" }
+			formatter.chain_append { _1.text "c" }
+
+			expect(output).to be == %(@_target << a << b << c)
+		end
+
+		it "allows for breaks" do
+			formatter.chain_append { _1.text "a" }
+
+			formatter.breakable(force: true)
+			formatter.text "b"
+			formatter.breakable(force: true)
+
+			formatter.chain_append { _1.text "c" }
+
+			expect(output).to be == %(@_target << a\nb\n@_target << c)
+		end
+	end
+
+	with "mixed appends" do
+		it "works" do
+			formatter.chain_append { _1.text "a" }
+			formatter.chain_append { _1.text "b" }
+			formatter.chain_append { _1.text "c" }
+
+			formatter.append { _1.text "d" }
+			formatter.append { _1.text "e" }
+			formatter.append { _1.text "f" }
+
+			formatter.chain_append { _1.text "g" }
+			formatter.chain_append { _1.text "h" }
+			formatter.chain_append { _1.text "i" }
+
+			expect(output).to be == %(@_target << a << b << c << "def" << g << h << i)
 		end
 	end
 end


### PR DESCRIPTION
Adds the ability to chain appends when formatting Ruby.