### PR TITLE
Create and document Phlex installation task for Rails

### DIFF
--- a/docs/pages/rails_integration.rb
+++ b/docs/pages/rails_integration.rb
@@ -7,6 +7,10 @@ module Pages
 				render Markdown.new(<<~MD)
 					# Ruby on Rails integration
 
+					## Installation
+
+					To install Phlex into your Rails application, you can run the `bin/rails phlex:install` command.
+
 					## Component generator
 
 					You can generate new views with the `rails g phlex:view` command.

--- a/lib/install/phlex.rb
+++ b/lib/install/phlex.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+say "Installing Phlex..."
+
+application_configuration_path = Rails.root.join("config/application.rb")
+application_configuration_content = File.read(application_configuration_path)
+
+pattern = %r(config.autoload_paths << (Rails.root.join\(.app.\)|.\#{root}/app.)\n)
+
+unless application_configuration_content.match?(pattern)
+	inject_into_class(
+		application_configuration_path,
+		"Application",
+		%(    config.autoload_paths << "\#{root}/app"\n)
+	)
+end
+
+say "Phlex successfully installed!"

--- a/lib/tasks/phlex_tasks.rake
+++ b/lib/tasks/phlex_tasks.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :phlex do
+	desc "Install Phlex in the Rails application"
+	task :install do
+		install_file_path = File.expand_path("../install/phlex.rb", __dir__)
+
+		system "#{RbConfig.ruby} bin/rails app:template LOCATION=#{install_file_path}"
+	end
+end


### PR DESCRIPTION
Closes #184

In this PR, we create an installation task with for Rails. Currently, it only does one thing: Add `config.autoload_paths << Rails.root.join("app")` in `config/application.rb` to enable autoloading from `app/views` while preserving the `Views` namespace.

Please let me know if you want me to add an initializer / configuration for Tailwind.