### PR TITLE
Add `helpers` proxy

### DIFF
--- a/docs/pages/rails_integration.rb
+++ b/docs/pages/rails_integration.rb
@@ -24,6 +24,30 @@ module Pages
 						end
 					end
 				RUBY
+
+				render Markdown.new(<<~MD)
+					## Helpers
+
+					You can use the `helpers` proxy to access helpers within a `Phlex::View`.
+
+					For example, you can use the `#t` helper for translations:
+				MD
+
+				render CodeBlock.new(<<~RUBY, syntax: :ruby)
+					# app/views/hello.rb
+
+					module Views
+						class Hello < Phlex::View
+						  delegate :t, to: :helpers
+
+							def template
+							  h1 do
+								  t "hello"
+								end
+							end
+						end
+					end
+				RUBY
 			end
 		end
 	end

--- a/lib/phlex/view.rb
+++ b/lib/phlex/view.rb
@@ -162,6 +162,10 @@ module Phlex
 			tokens.compact.join(" ")
 		end
 
+		def helpers
+			@_view_context
+		end
+
 		def _attributes(attributes, buffer: +"")
 			if attributes[:href]&.start_with?(/\s*javascript/)
 				attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "")


### PR DESCRIPTION
This PR adds the `helpers` proxy to be able to access helpers within a `Phlex::View`.

For example, you can use the `#t` helper provided in Rails views for translations:
```ruby
class Hello < Phlex::View
  delegate :t, to: :helpers
  
  def template
    h1 do
      t "hello"
    end
  end
end
```