### PR TITLE
Include URL helpers in ApplicationView

### DIFF
--- a/lib/install/phlex.rb
+++ b/lib/install/phlex.rb
@@ -17,11 +17,13 @@ end
 
 unless Rails.root.join("app/views/application_view.rb").exist?
 	create_file(Rails.root.join("app/views/application_view.rb"), <<~RUBY)
-  # frozen_string_literal: true
+		# frozen_string_literal: true
 
-  class Views::ApplicationView < Phlex::View
-    # Base class for your views
-  end
+		module Views
+		  class ApplicationView < Phlex::View
+		    include Rails.application.routes.url_helpers
+		  end
+		end
 	RUBY
 end
 


### PR DESCRIPTION
These helpers could already be accessed through the `helpers` proxy introduced in #201 but I think it makes sense to include them directly in the `ApplicationView` by default.