### PR TITLE
Collections as modules

### DIFF
--- a/lib/phlex/collection.rb
+++ b/lib/phlex/collection.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Phlex
-	class Collection < Phlex::View
+	module Collection
 		def initialize(collection: nil, item: nil)
 			unless collection || item
 				raise ArgumentError,

--- a/lib/phlex/table.rb
+++ b/lib/phlex/table.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 module Phlex
-	class Table < Phlex::Collection
-		class << self
+	module Table
+		include Collection
+
+		module ClassMethods
 			def property(header, &block)
 				if header.is_a?(String)
 					header_text = header
@@ -18,6 +20,10 @@ module Phlex
 			def properties
 				@properties ||= []
 			end
+		end
+
+		def self.included(child)
+			child.extend(ClassMethods)
 		end
 
 		def collection_template


### PR DESCRIPTION
Because we encourage inheriting from `ApplicationView`, we need to provide standard library views as modules to be mixed into an `ApplicationView` rather than classes to inherit from.