### PR TITLE
Improve collections

### DIFF
--- a/lib/phlex/collection.rb
+++ b/lib/phlex/collection.rb
@@ -2,18 +2,24 @@
 
 module Phlex
 	module Collection
-		def initialize(collection: nil, item: nil)
+		def initialize(collection: nil, item: nil, index: nil, position: nil, first: nil, last: nil, collection_size: nil)
 			unless collection || item
-				raise ArgumentError,
-					"You must pass a collection or an item as a keyword argument."
+				raise ArgumentError, "You must pass a collection or an item as a keyword argument."
 			end
 
 			if collection && item
-				raise ArgumentError,
-					"You can pass either a collection or an item as a keyword argument but not both."
+				raise ArgumentError, "You can pass either a collection or an item as a keyword argument but not both."
 			end
 
-			@collection = collection or @item = item
+			if (@item = item)
+				@index = index
+				@position = position
+				@first = first
+				@last = last
+				@collection_size = collection_size
+			else
+				@collection = collection
+			end
 		end
 
 		def template
@@ -28,13 +34,31 @@ module Phlex
 
 		def yield_items
 			if @item
-				raise NoMethodError,
-					"You can only yield_items when rendering a collection. You're already rendering an item."
+				raise ArgumentError, "You can only yield_items when rendering a collection. This instance is rendering an item."
 			end
 
-			@collection.each do |item|
-				render self.class.new(item: item)
+			@collection.each_with_index do |item, index|
+				render self.class.new(
+					item: item,
+					index: index,
+					first: (index == 0),
+					last: (index == @collection.size - 1),
+					position: (index + 1),
+					collection_size: @collection.size
+				)
 			end
+		end
+
+		def first?
+			raise ArgumentError if @collection
+
+			@first
+		end
+
+		def last?
+			raise ArgumentError if @collection
+
+			@last
 		end
 	end
 end

--- a/lib/phlex/collection.rb
+++ b/lib/phlex/collection.rb
@@ -17,7 +17,11 @@ module Phlex
 		end
 
 		def template
-			@collection ? collection_template : item_template
+			if @collection
+				collection_template { yield_items }
+			else
+				item_template
+			end
 		end
 
 		private


### PR DESCRIPTION
Pass a block to the collection template, yielding items. This means you can write shorter collection templates, e.g.

```ruby
def collection_template(&) = ul(&)
```

Also add support for `first?` and `last?` predicates for items.

```ruby
def item_template
  p **classes(first?: "border-t-1", last?: "border-b-1") { @item.title }
end
```

I wouldn't actually recommend using this for styling, since that can be achieved with CSS selectors and the first and last predicates need to be set manually when rendering a single item outside of a collection.

Also added support for accessing `@index`, `@position`, and `@collection_size` from an item.

```ruby
def item_template
  span { "#{@position} of #{@collection_size}" }
end
```