### PR TITLE
Remove Rspec from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,7 @@
 
 require "bundler/gem_tasks"
 
-begin
-	require "rspec/core/rake_task"
-	RSpec::Core::RakeTask.new(:spec)
+task :sus do
+	sh "bundle exec sus"
 end
-
-task default: :spec
+task default: :sus


### PR DESCRIPTION
Replaced the RSpec runner in the Rakefile with a shell out to sus. Not perfect, but better than running `rake` at the root and seeing rspec errors.