### PR TITLE
Initial i18n support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "webrick", group: [:docs]
 gem "zeitwerk", group: [:docs]
 gem "redcarpet", group: [:docs]
 gem "combustion", group: [:test]
+gem "i18n", group: [:test]
 gem "benchmark-ips"
 gem "htmlbeautifier", group: [:docs]
 gem "benchmark-memory"

--- a/lib/install/phlex.rb
+++ b/lib/install/phlex.rb
@@ -22,6 +22,7 @@ unless Rails.root.join("app/views/application_view.rb").exist?
 		module Views
 		  class ApplicationView < Phlex::View
 		    include Rails.application.routes.url_helpers
+		    include Phlex::I18n
 		  end
 		end
 	RUBY

--- a/lib/phlex/i18n.rb
+++ b/lib/phlex/i18n.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Phlex
+	module I18n
+		def translate(key, **options)
+			::I18n.translate(key, **options)
+		end
+
+		alias_method :t, :translate
+	end
+end

--- a/test/phlex/i18n.rb
+++ b/test/phlex/i18n.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Phlex::I18n do
+	extend ViewHelper
+
+	view do
+		include Phlex::I18n
+
+		def template
+			text translate("hello")
+		end
+	end
+
+	it "supports I18n translations" do
+		expect(I18n).to receive(:translate).with("hello").and_return "hola"
+		expect(output).to be == "hola"
+	end
+end


### PR DESCRIPTION
Add support for I18n translations through the `translate` and `t` methods on views that include `Phlex::I18n`.