### PR TITLE
Remove positional content

### DIFF
--- a/docs/components/layout.rb
+++ b/docs/components/layout.rb
@@ -14,7 +14,7 @@ module Components
 			html do
 				head do
 					meta charset: "utf-8"
-					title @title
+					title { @title }
 					link href: "/application.css", rel: "stylesheet"
 					style { raw Rouge::Theme.find("github").render(scope: ".highlight") }
 				end
@@ -26,11 +26,11 @@ module Components
 
 							nav do
 								ul do
-									li { a "Introduction", href: "/" }
-									li { a "Templates", href: "/templates" }
-									li { a "Views", href: "/views" }
-									li { a "Rails integration", href: "/rails-integration" }
-									li { a "Source code", href: "https://github.com/joeldrapper/phlex" }
+									li { a(href: "/") { "Introduction" } }
+									li { a(href: "/templates") { "Templates" } }
+									li { a(href: "/views") { "Views" } }
+									li { a(href: "/rails-integration") { "Rails integration" } }
+									li { a(href: "https://github.com/joeldrapper/phlex") { "Source code" } }
 								end
 							end
 						end

--- a/docs/components/tabs/tab.rb
+++ b/docs/components/tabs/tab.rb
@@ -11,7 +11,9 @@ module Components
 			def template(&block)
 				input class: "opacity-0 fixed peer", type: "radio", name: @_parent.unique_identifier, id: unique_identifier, checked: @checked
 
-				label @name, id: "#{unique_identifier}-label", for: unique_identifier, role: "tab", aria_controls: "#{unique_identifier}-panel", class: "order-1 py-2 px-5 bg-white text-sm border border-b-0 border-l-0 font-medium first-of-type:border-l first-of-type:rounded-tl last-of-type:rounded-tr before:absolute before:pointer-events-none before:w-full before:ring before:h-full before:left-0 before:top-0 before:hidden before:rounded peer-focus:before:block cursor-pointer"
+				label id: "#{unique_identifier}-label", for: unique_identifier, role: "tab", aria_controls: "#{unique_identifier}-panel", class: "order-1 py-2 px-5 bg-white text-sm border border-b-0 border-l-0 font-medium first-of-type:border-l first-of-type:rounded-tl last-of-type:rounded-tr before:absolute before:pointer-events-none before:w-full before:ring before:h-full before:left-0 before:top-0 before:hidden before:rounded peer-focus:before:block cursor-pointer" do
+					@name
+				end
 
 				div id: "#{unique_identifier}-panel", role: "tabpanel", aria_labelledby: "#{unique_identifier}-label", class: "tab hidden order-2 w-full border rounded-b rounded-tr overflow-hidden" do
 					@_parent.instance_exec(&block)

--- a/docs/pages/templates.rb
+++ b/docs/pages/templates.rb
@@ -18,7 +18,7 @@ module Pages
 					e.tab "heading.rb", <<~RUBY
 						class Heading < Phlex::View
 							def template
-								h1 "Hello World!"
+								h1 { "Hello World!" }
 							end
 						end
 					RUBY
@@ -38,9 +38,9 @@ module Pages
 					e.tab "heading.rb", <<~RUBY
 						class Heading < Phlex::View
 							def template
-								h1 "Hello World!",
-									class: "text-xl font-bold",
-									aria_details: "details"
+								h1 class: "text-xl font-bold", aria_details: "details" do
+									"Hello World!"
+								end
 							end
 						end
 					RUBY
@@ -77,9 +77,9 @@ module Pages
 							def template
 								nav do
 									ul do
-										li { a "Home", href: "/" }
-										li { a "About", href: "/about" }
-										li { a "Contact", href: "/contact" }
+										li { a(href: "/") { "Home" } }
+										li { a(href: "/about") { "About" } }
+										li { a(href: "/contact") { "Contact" } }
 									end
 								end
 							end
@@ -99,7 +99,10 @@ module Pages
 					e.tab "heading.rb", <<~RUBY
 						class Heading < Phlex::View
 							def template
-								h1 { strong "Hello "; text "World!" }
+								h1 do
+									strong { "Hello " }
+									text "World!"
+								end
 							end
 						end
 					RUBY
@@ -117,11 +120,11 @@ module Pages
 					e.tab "links.rb", <<~RUBY
 						class Links < Phlex::View
 							def template
-								a "Home", href: "/"
+								a(href: "/") { "Home" }
 								whitespace
-								a "About", href: "/about"
+								a(href: "/about") { "About" }
 								whitespace
-								a "Contact", href: "/contact"
+								a(href: "/contact") { "Contact" }
 							end
 						end
 					RUBY
@@ -151,8 +154,8 @@ module Pages
 							end
 
 							def template
-								a @text, href: @to, class: tokens("nav-item",
-									active?: "nav-item-active")
+								a(href: @to, class: tokens("nav-item",
+									active?: "nav-item-active")) { @text }
 							end
 
 							private
@@ -191,8 +194,8 @@ module Pages
 							end
 
 							def template
-								a @text, href: @to, **classes("nav-item",
-									active?: "nav-item-active")
+								a(href: @to, **classes("nav-item",
+									active?: "nav-item-active")) { @text }
 							end
 
 							private

--- a/docs/pages/views.rb
+++ b/docs/pages/views.rb
@@ -17,7 +17,7 @@ module Pages
 						class Card < Phlex::View
 							def template(&)
 								article(class: "drop-shadow rounded p-5") {
-									h1 "Amazing content!"
+									h1 { "Amazing content!" }
 									yield_content(&)
 								}
 							end
@@ -56,7 +56,7 @@ module Pages
 						class Example < Phlex::View
 							def template
 								render Card.new do
-									h1 "Hello"
+									h1 { "Hello" }
 								end
 							end
 						end
@@ -111,7 +111,7 @@ module Pages
 							end
 
 							def template
-								h1 "Hello \#{@name}!"
+								h1 { "Hello \#{@name}!" }
 							end
 						end
 					RUBY
@@ -143,7 +143,7 @@ module Pages
 							end
 
 							def template
-								span status_emoji
+								span { status_emoji }
 							end
 
 							private

--- a/fixtures/dummy/app/views/card.rb
+++ b/fixtures/dummy/app/views/card.rb
@@ -7,7 +7,9 @@ module Views
 		end
 
 		def title(text)
-			h3 text, class: "font-bold"
+			h3 class: "font-bold" do
+				text
+			end
 		end
 	end
 end

--- a/fixtures/dummy/app/views/comments/comment.rb
+++ b/fixtures/dummy/app/views/comments/comment.rb
@@ -10,13 +10,13 @@ module Views
 
 			def template(&block)
 				div {
-					span @name
-					span @body
+					span { @name }
+					span { @body }
 
 					yield_content(&block)
 
 					render(::ReactionComponent.new(emoji: "hamburger")) do
-						p "Emoji reaction for a comment from #{@name} with body #{@body}"
+						p { "Emoji reaction for a comment from #{@name} with body #{@body}" }
 					end
 				}
 			end

--- a/fixtures/dummy/app/views/comments/reaction.rb
+++ b/fixtures/dummy/app/views/comments/reaction.rb
@@ -8,7 +8,7 @@ module Views
 			end
 
 			def template(&block)
-				p @emoji
+				p { @emoji }
 
 				yield_content(&block)
 			end

--- a/lib/generators/phlex/collection/templates/collection.rb.erb
+++ b/lib/generators/phlex/collection/templates/collection.rb.erb
@@ -8,7 +8,7 @@ module Views
     end
 
     def item_template
-      li @item
+      li { @item }
     end
   end
 end

--- a/lib/generators/phlex/layout/templates/layout.rb.erb
+++ b/lib/generators/phlex/layout/templates/layout.rb.erb
@@ -16,7 +16,7 @@ module Views
           csp_meta_tag
           csrf_meta_tags
           meta name: "viewport", content: "width=device-width,initial-scale=1"
-          title @title
+          title { @title }
           stylesheet_link_tag "application"
         end
 

--- a/lib/generators/phlex/page/templates/page.rb.erb
+++ b/lib/generators/phlex/page/templates/page.rb.erb
@@ -3,7 +3,7 @@ module Views
   class <%= class_name %> < ApplicationView
     def template
       render Layout.new(title: "<%= class_name.gsub("::", " ") %>") do
-        h1 "👋 Hello World!"
+        h1 { "👋 Hello World!" }
       end
     end
   end

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -129,11 +129,9 @@ module Phlex
 			class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
         # frozen_string_literal: true
 
-        def #{element}(content = nil, **attributes, &block)
+        def #{element}(**attributes, &block)
           if attributes.length > 0
-            if content
-              @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(attributes)) << ">" << CGI.escape_html(content) << "</#{tag}>"
-            elsif block_given?
+            if block_given?
               @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(attributes)) << ">"
               yield_content(&block)
               @_target << "</#{tag}>"
@@ -141,16 +139,7 @@ module Phlex
               @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(attributes)) << "></#{tag}>"
             end
           else
-            if content
-              case content
-              when String
-                @_target << "<#{tag}>" << CGI.escape_html(content) << "</#{tag}>"
-              when Symbol
-                @_target << "<#{tag}>" << CGI.escape_html(content.name) << "</#{tag}>"
-              else
-                @_target << "<#{tag}>" << CGI.escape_html(content.to_s) << "</#{tag}>"
-              end
-            elsif block_given?
+            if block_given?
               @_target << "<#{tag}>"
               yield_content(&block)
               @_target << "</#{tag}>"

--- a/test/phlex/view/custom_elements.rb
+++ b/test/phlex/view/custom_elements.rb
@@ -13,7 +13,7 @@ describe Phlex::View do
 			def template
 				div do
 					trix_toolbar
-					trix_editor "Hello"
+					trix_editor { "Hello" }
 				end
 			end
 		end

--- a/test/phlex/view/naughty_business.rb
+++ b/test/phlex/view/naughty_business.rb
@@ -32,7 +32,9 @@ describe Phlex::View do
 	with "naughty javascript link protocol in href" do
 		view do
 			def template
-				a "naughty link", href: "javascript:javascript:alert(1)"
+				a href: "javascript:javascript:alert(1)" do
+					"naughty link"
+				end
 			end
 		end
 

--- a/test/phlex/view/numbers.rb
+++ b/test/phlex/view/numbers.rb
@@ -8,26 +8,9 @@ describe Phlex::View do
 	with "numbers" do
 		view do
 			def template
-				span 1
-				span 2.0
-			end
-		end
+				span { 1 }
 
-		it "produces the correct output" do
-			expect(output).to be == "<span>1</span><span>2.0</span>"
-		end
-	end
-
-	with "numbers in block" do
-		view do
-			def template
-				span do
-					1
-				end
-
-				span do
-					2.0
-				end
+				span { 2.0 }
 			end
 		end
 

--- a/test/phlex/view/renderable/render.rb
+++ b/test/phlex/view/renderable/render.rb
@@ -32,7 +32,7 @@ describe Phlex::View do
 				view do
 					define_method :template do
 						render(other_view.new) do
-							h1 "Hi!"
+							h1 { "Hi!" }
 						end
 					end
 				end

--- a/test/phlex/view/tags.rb
+++ b/test/phlex/view/tags.rb
@@ -6,22 +6,10 @@ describe Phlex::View do
 	extend ViewHelper
 
 	Phlex::HTML::STANDARD_ELEMENTS.each do |method_name, tag|
-		with "<#{method_name}> with text content and attributes" do
-			view do
-				define_method :template do
-					send(method_name, "content", class: "class", id: "id", disabled: true, selected: false)
-				end
-			end
-
-			it "produces the correct output" do
-				expect(output).to be == %(<#{tag} class="class" id="id" disabled>content</#{tag}>)
-			end
-		end
-
 		with "<#{method_name}> with block content and attributes" do
 			view do
 				define_method :template do
-					send(method_name, class: "class", id: "id", disabled: true, selected: false) { h1 "Hello" }
+					send(method_name, class: "class", id: "id", disabled: true, selected: false) { h1 { "Hello" } }
 				end
 			end
 

--- a/test/phlex/view/tokens.rb
+++ b/test/phlex/view/tokens.rb
@@ -9,7 +9,9 @@ describe Phlex::View do
 		with "symbol conditionals" do
 			view do
 				def template
-					a "Home", href: "/", **classes("a", "b", "c", active?: "active", primary?: "primary")
+					a href: "/", **classes("a", "b", "c", active?: "active", primary?: "primary") do
+						"Home"
+					end
 				end
 
 				def active?
@@ -30,9 +32,11 @@ describe Phlex::View do
 		with "proc conditionals" do
 			view do
 				def template
-					a "Home", href: "/", **classes("a", "b", "c",
+					a href: "/", **classes("a", "b", "c",
 						-> { true } => "true",
-						-> { false } => "false")
+						-> { false } => "false") do
+						"Home"
+					end
 				end
 			end
 

--- a/test/phlex/view/whitespace.rb
+++ b/test/phlex/view/whitespace.rb
@@ -8,9 +8,9 @@ describe Phlex::View do
 	with "whitespace" do
 		view do
 			def template
-				a "Home"
+				a { "Home" }
 				whitespace
-				a "About"
+				a { "About" }
 			end
 		end
 


### PR DESCRIPTION
For a long time now, we've supported block-based text content `h1 { "Hello" }` and positional text content `h1 "Hello"` and I think this inconsistency hurts the framework and the developer experience.

I might be wrong, but it’s much easier to add it back as a non-breaking change after `1.0` than it is to remove it after `1.0` so it’s going for now.

This PR probably doesn't catch everything, especially around generators and documentation, but it’s a start.