### PR TITLE
Another crack at "Experimental view methods"

### DIFF
--- a/docs/components/tabs.rb
+++ b/docs/components/tabs.rb
@@ -13,7 +13,7 @@ module Components
 		end
 
 		def tab(name, &block)
-			render(Tab.new(name: name, checked: first?), &block)
+			Tab name: name, checked: first?, &block
 			@index += 1
 		end
 

--- a/docs/components/tabs/tab.rb
+++ b/docs/components/tabs/tab.rb
@@ -3,6 +3,8 @@
 module Components
 	class Tabs
 		class Tab < Phlex::View
+			include Phlex::RegisterableComponent
+
 			def initialize(name:, checked:)
 				@name = name
 				@checked = checked

--- a/lib/phlex/component_registry.rb
+++ b/lib/phlex/component_registry.rb
@@ -35,8 +35,12 @@ module Phlex
                        .find(&:itself)
 
       component ||= @components[""][component_name]
-      @cache[[component_name, context]] = component
+      cache_fetch(component_name, context, component)
       component
+    end
+
+    def cache_fetch(component_name, context, component)
+      @cache[[component_name, context]] = component
     end
   end
 end

--- a/lib/phlex/component_registry.rb
+++ b/lib/phlex/component_registry.rb
@@ -1,0 +1,42 @@
+require "singleton"
+
+module Phlex
+  class ComponentRegistry
+    include Singleton
+
+    def initialize
+      @components = {}
+      @cache = {}
+    end
+
+    def register(component)
+      parts = component.name.split("::")
+      path_pairs = parts.size.times.map { |n| [parts[0, n], parts[n, parts.size]] }
+
+      path_pairs.each do |(parent, child)|
+        parent = parent.join("::")
+        child = child.join("_").to_sym
+        @components[parent] ||= {}
+        @components[parent][child] = component
+      end
+    end
+
+    def fetch(component_name, context)
+      cached_fetch = @cache[[component_name, context]]
+      return cached_fetch if cached_fetch.present?
+
+      parts = context.name.split("::")
+      component = parts.size
+                       .times
+                       .lazy
+                       .map { |n| parts.first(parts.size - n) }
+                       .map { |path_parts| path_parts.join("::") }
+                       .map { |path| @components.dig(path, component_name) }
+                       .find(&:itself)
+
+      component ||= @components[""][component_name]
+      @cache[[component_name, context]] = component
+      component
+    end
+  end
+end

--- a/lib/phlex/registerable_component.rb
+++ b/lib/phlex/registerable_component.rb
@@ -1,0 +1,7 @@
+module Phlex
+  module RegisterableComponent
+    def self.included(base)
+      ComponentRegistry.instance.register(base)
+    end
+  end
+end

--- a/lib/phlex/renderable.rb
+++ b/lib/phlex/renderable.rb
@@ -8,7 +8,10 @@ module Phlex
 					block = Phlex::Block.new(self, &block)
 				end
 
+				@_original_wrapper = @_wrapper
+				@_wrapper = renderable
 				renderable.call(@_target, view_context: @_view_context, parent: self, &block)
+				@_wrapper = @_original_wrapper
 			elsif renderable.is_a?(Class) && renderable < View
 				raise ArgumentError, "You tried to render the Phlex view class: #{renderable.name} but you probably meant to render an instance of that class instead."
 			else

--- a/lib/phlex/view.rb
+++ b/lib/phlex/view.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "benchmark"
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
 	using Overrides::Symbol::Name
@@ -42,6 +43,15 @@ module Phlex
 
 			buffer
 		end
+
+		def method_missing(name, *args, **kwargs, &block)
+			view_class = ComponentRegistry.instance.fetch(name, self.class)
+
+			# we can include the slow method as fallback / when eager loading is disabled, omitted while trying it out
+
+			render view_class.new(*args, **kwargs), &block
+		end
+
 
 		def rendered?
 			@_rendered ||= false

--- a/lib/phlex/view.rb
+++ b/lib/phlex/view.rb
@@ -48,6 +48,7 @@ module Phlex
 			view_class = ComponentRegistry.instance.fetch(name, self.class)
 
 			# we can include the slow method as fallback / when eager loading is disabled, omitted while trying it out
+			view_class ||= (@_wrapper || self).instance_eval name.to_s.gsub("_", "::")
 
 			render view_class.new(*args, **kwargs), &block
 		end


### PR DESCRIPTION
Whattup @joeldrapper I liked https://github.com/joeldrapper/phlex/pull/252 and I think we should keep trying.

This strategy depends on eager loading to build a lookup where a component registers itself at every level of their namespace on up, and callers of components in this style search for the component they're looking for from their namespace on up. We'll need to use the naive lookup in your original PR when eager loading is disabled.

We pay the cost up front at app start because who cares? Plus it can be optional behavior. All you gotta do is drop the module into your component and you're good.

I'm not sure what kind of benchmarks your efforts didn't pass but why not give them a try here?