### PR TITLE
Add Phlex components to Tailwind configuration

### DIFF
--- a/lib/install/phlex.rb
+++ b/lib/install/phlex.rb
@@ -27,4 +27,12 @@ unless Rails.root.join("app/views/application_view.rb").exist?
 	RUBY
 end
 
+tailwind_config_path = Rails.root.join("config/tailwind.config.js")
+
+if tailwind_config_path.exist?
+	insert_into_file tailwind_config_path, after: "content: [" do
+		"\n    './app/views/**/*.rb',"
+	end
+end
+
 say "Phlex successfully installed!"


### PR DESCRIPTION
Phlex components are Ruby files, so they have a `.rb` extension.

That's why, to be able to use Phlex components with Tailwind, we need to add the `.rb` extension to the list of files that Tailwind should look at when generating CSS.

This is done in the `config/tailwind.config.js`:

```js
module.exports = {
  content: [
    './public/*.html',
    './app/helpers/**/*.rb',
    './app/javascript/**/*.js',
    './app/views/**/*.{slim,erb}',
  ],
```

Thanks to this commit, we automatically add the following configuration line to add `.rb` files in `app/views` to the list of files processed by Tailwind. Running `rails phlex:install` will add `'./app/views/**/*.rb',` to the list: 

```diff
 module.exports = {
   content: [
+    './app/views/**/*.rb',
     './public/*.html',
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js',
     './app/views/**/*.{slim,erb}',
   ],
 }
```