### PR TITLE
Remove redundant slash in void elements

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -164,9 +164,9 @@ module Phlex
 
         def #{element}(**attributes)
           if attributes.length > 0
-            @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(attributes)) << " />"
+            @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(attributes)) << ">"
           else
-            @_target << "<#{tag} />"
+            @_target << "<#{tag}>"
           end
 
           nil

--- a/test/phlex/view/tags.rb
+++ b/test/phlex/view/tags.rb
@@ -40,7 +40,7 @@ describe Phlex::View do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{tag} class="class" id="id" disabled />)
+				expect(output).to be == %(<#{tag} class="class" id="id" disabled>)
 			end
 		end
 	end


### PR DESCRIPTION
The redundant slash actually causes HTML validation warnings. I think we should remove it.