### PR TITLE
WIP: Add `render_view` test helper

### DIFF
--- a/docs/components/layout.rb
+++ b/docs/components/layout.rb
@@ -51,6 +51,7 @@ module Components
 										render Nav::Item.new("Views", to: Pages::Views, active_page: @_parent)
 										render Nav::Item.new("Templates", to: Pages::Templates, active_page: @_parent)
 										render Nav::Item.new("Helpers", to: Pages::Helpers, active_page: @_parent)
+										render Nav::Item.new("Testing", to: Pages::Testing, active_page: @_parent)
 									end
 
 									h2(class: "text-lg font-semibold pt-5") { "Rails" }

--- a/docs/pages/testing.rb
+++ b/docs/pages/testing.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Pages
+	class Testing < ApplicationPage
+		def template
+			render Layout.new(title: "Testing") do
+				render Markdown.new(<<~MD)
+					# Testing
+
+					## RSpec
+
+					Add test helpers to your suite:
+
+					```ruby
+					# spec/support/phlex.rb
+					require "phlex/test_helpers"
+
+					RSpec.configure do |config|
+						config.include Phlex::TestHelpers, type: :view
+					end
+					```
+
+					Remember to require this file in `rails_helper.rb` uncommenting the following line:
+
+					```ruby
+					Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+					```
+
+					### Asserting without capybara
+
+					```ruby
+					# menu.rb
+					class Menu < Phlex::View
+						def template
+							ul do
+								li do
+									a(href: "/") { "Home" }
+									a(href: "/sign_in") { "Sign In" }
+							  end
+							end
+						end
+					end
+
+					# menu_spec.rb
+					it "renders Home menu item" do
+						result = render_view(Menu.new)
+
+						selector = result.css('ul li a[href="/"]:contains("Home")')
+						expect(selector).to be_present
+					end
+					```
+
+					### Asserting with capybara
+					Setup capybara:
+
+					```ruby
+					# spec/support/capybara.rb
+					require "capybara/rspec"
+
+					RSpec.configure do |config|
+						config.include Capybara::RSpecMatchers, type: :view
+					end
+					```
+
+					You are now able to use capybara matchers:
+
+					```ruby
+					# menu_spec.rb
+					it "renders Home menu item" do
+						result = render_view(Menu.new)
+
+						expect(result).to have_link("Home", href: "/")
+					end
+					```
+
+					### Passing blocks
+
+					You can pass blocks to `render_view`:
+
+					```ruby
+					it "renders items" do
+						result = render_view(Nav.new) do |nav|
+							nav.item(href: "/products/new") { "New Product" }
+							nav.item(href: "/categories/new") { "New Category" }
+						end
+
+						expect(result).to have_link("New", href: "/products/new")
+					end
+					```
+				MD
+			end
+		end
+	end
+end

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -7,6 +7,7 @@ require "syntax_tree"
 loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.ignore("#{__dir__}/generators")
 loader.ignore("#{__dir__}/install")
+loader.ignore("#{__dir__}/phlex/test_helpers.rb")
 loader.inflector.inflect("html" => "HTML")
 loader.inflector.inflect("vcall" => "VCall")
 loader.inflector.inflect("fcall" => "FCall")

--- a/lib/phlex/test_helpers.rb
+++ b/lib/phlex/test_helpers.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Phlex
+	module TestHelpers
+		def render_view(view, &block)
+			rendered = controller.view_context.render(view, &block)
+			Nokogiri::HTML.fragment(rendered)
+		end
+
+		def controller
+			ActionView::TestCase::TestController.new
+		end
+	end
+end

--- a/test/phlex/test_helpers.rb
+++ b/test/phlex/test_helpers.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "phlex/test_helpers"
+
+describe Phlex::TestHelpers do
+	include Phlex::TestHelpers
+
+	describe "#render_view" do
+		it "parses rendered string in to a nokogiri nodeset" do
+			view = Class.new(Phlex::View) do
+				def template
+					h2 { "Some title" }
+				end
+			end
+
+			output = render_view(view.new)
+
+			expect(output.class).to be == Nokogiri::HTML::DocumentFragment
+		end
+
+		it "accepts content block" do
+			nav_view = Class.new(Phlex::View) do
+				def template(&content)
+					ul(&content)
+				end
+
+				def item(&content)
+					li(&content)
+				end
+			end
+
+			output = render_view(nav_view.new) do |nav|
+				nav.item { "Menu A" }
+				nav.item { "Menu B" }
+			end
+
+			expect(output.to_s).to be == %(<ul>\n<li>Menu A</li>\n<li>Menu B</li>\n</ul>)
+		end
+	end
+end


### PR DESCRIPTION
A first attempt to add test helpers. What do you think? 
The documentation is still pretty sketchy, I didn't try the helper with Minitest yet, and it is too attached with Rails.

I'm extracting this from my project:
The helper method:
https://github.com/stephannv/nindika/blob/main/spec/support/phlex.rb#L3-L9

Usage:
https://github.com/stephannv/nindika/blob/main/spec/views/layouts/navbar_component_spec.rb#L6-L10

With this helper (and capybara) will be possible to do something like:
```ruby
result = render_view(my_view.new) 
expect(result).to have_link("Home", href: "/")
```