### PR TITLE
Improve Minitest/Capybara integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rake"
 
 gem "sus", group: [:test]
 gem "rails", group: [:test]
+gem "capybara", group: [:test]
 gem "rouge", group: [:docs]
 gem "webrick", group: [:docs]
 gem "zeitwerk", group: [:docs]

--- a/docs/pages/testing/minitest.rb
+++ b/docs/pages/testing/minitest.rb
@@ -73,16 +73,22 @@ module Pages
 
 						In addition to `css` you can use other Nokogiri finders like `xpath`, `at_css`, `at_xpath`. Read more about Nokogiri here: [https://nokogiri.org/](https://nokogiri.org/).
 
-						## Asserting with capybara (Coming Soon)
+						## Asserting with capybara
+
 						Setup capybara following the documentation: [https://github.com/teamcapybara/capybara#using-capybara-with-minitest](https://github.com/teamcapybara/capybara#using-capybara-with-minitest)
 
 						You are now able to use capybara matchers:
 
 						```ruby
 						# menu_spec.rb
+						require 'capybara/minitest'
+
 						class MenuTest < ActionView::TestCase # or Minitest::Test
+							include Phlex::TestHelpers
+							include Capybara::Minitest::Assertions
+
 							def test_it_renders_home_menu
-								render_view(MenuTest)
+								render_view(Menu.new)
 
 								assert_link "Home", href: "/"
 							end
@@ -90,12 +96,18 @@ module Pages
 						```
 
 						You can find more Capybara matchers here: [https://github.com/teamcapybara/capybara](https://github.com/teamcapybara/capybara).
+
 						### Passing blocks
 
 						You can pass blocks to `render_view`:
 
 						```ruby
+						require 'capybara/minitest'
+
 						class NavTest < ActionView::TestCase # or Minitest::Test
+							include Phlex::TestHelpers
+							include Capybara::Minitest::Assertions
+
 							def test_it_accepts_items
 								render_view(Nav.new) do |nav|
 									nav.item(href: "/products/new") { "New Product" }

--- a/lib/phlex/test_helpers.rb
+++ b/lib/phlex/test_helpers.rb
@@ -4,11 +4,15 @@ module Phlex
 	module TestHelpers
 		class MissingTestDependency < StandardError; end
 
+		attr_reader :rendered
+
 		def render_view(view, &block)
-			ensure_presence_of_nokogiri
+			ensure_presence_of_nokogiri!
+
+			@page = nil # page is memoized with rendered , this will force page to be evaluated with new content
 
 			view_context = controller&.view_context
-			rendered = view.call(view_context: view_context, &block)
+			@rendered = view.call(view_context: view_context, &block)
 			Nokogiri::HTML.fragment(rendered)
 		end
 
@@ -20,12 +24,27 @@ module Phlex
 			end
 		end
 
+		def page
+			@page ||= begin
+				ensure_presence_of_capybara!
+
+				Capybara::Node::Simple.new(rendered)
+			end
+		end
+
 		private
 
-		def ensure_presence_of_nokogiri
+		def ensure_presence_of_nokogiri!
 			return if defined?(Nokogiri)
 
 			message = "You need to add `nokogiri` to your application dependencies in order to use `render_view` method"
+			raise MissingTestDependency, message
+		end
+
+		def ensure_presence_of_capybara!
+			return if defined?(Capybara)
+
+			message = "You need to add `capybara` to your application dependencies in order to assert against rendered view"
 			raise MissingTestDependency, message
 		end
 	end


### PR DESCRIPTION
This PR will allows capybara assertions works with minitest. Capybara uses `page` when `assert_link`, `assert_button`, `assert_text`, etc. are called.
It is now is possible to do this:
```ruby
def test_it_renders_contact_menu
  render_view(Nav.new)

  assert_link "Contact", href: "/contact"
end
```