### PR TITLE
feat: Dynamically defined Rails helpers

### DIFF
--- a/fixtures/dummy/app/views/articles/form.rb
+++ b/fixtures/dummy/app/views/articles/form.rb
@@ -3,7 +3,7 @@
 module Views
 	module Articles
 		class Form < Phlex::View
-			include Phlex::Rails::Helpers::FormWith
+			include Phlex::Rails::Helpers
 
 			def template
 				form_with url: "test" do |f|

--- a/fixtures/dummy/app/views/articles/show.html.erb
+++ b/fixtures/dummy/app/views/articles/show.html.erb
@@ -1,0 +1,1 @@
+<%= render Views::LinkHome.new %>

--- a/fixtures/dummy/app/views/articles/show_with_image.html.erb
+++ b/fixtures/dummy/app/views/articles/show_with_image.html.erb
@@ -1,0 +1,1 @@
+<%= render Views::LinkHomeWithImage.new %>

--- a/fixtures/dummy/app/views/link_home.rb
+++ b/fixtures/dummy/app/views/link_home.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Views
+	class LinkHome < Phlex::View
+		include Phlex::Rails::Helpers
+
+		def template
+			link_to "Go Back Home", :root
+		end
+	end
+end

--- a/fixtures/dummy/app/views/link_home_with_image.rb
+++ b/fixtures/dummy/app/views/link_home_with_image.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Views
+	class LinkHomeWithImage < Phlex::View
+		include Phlex::Rails::Helpers
+
+		def template
+			link_to :root, class: "link" do
+				text "Go Back Home"
+				img src: "/go/back.gif"
+			end
+		end
+	end
+end

--- a/fixtures/dummy/config/routes.rb
+++ b/fixtures/dummy/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-	# Rails routes here
+	root to: "articles#index"
 end

--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -4,30 +4,26 @@ module Phlex
 	module Rails
 		module Helpers
 			HELPERS = %w[csp_meta_tag csrf_meta_tags action_cable_meta_tag stylesheet_link_tag
-				favicon_link_tag preload_link_tag javascript_include_tag link_to mail_to].freeze
+				favicon_link_tag preload_link_tag javascript_include_tag link_to mail_to form_with].freeze
 
 			HELPERS.each do |name|
 				class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
-        	# frozen_string_literal: true
+					# frozen_string_literal: true
 
-					def #{name}(...)
-						if (output = @_view_context.#{name}(...))
-							@_target << output
+					def #{name}(*args, **kwargs, &block)
+						if block_given?
+							raw @_view_context.#{name}(*args, **kwargs) { |x|
+								capture do
+									yield Phlex::Buffered.new(x, buffer: @_target)
+								end
+							}
+						else
+							if (output = @_view_context.#{name}(*args, **kwargs))
+								@_target << output
+							end
 						end
 					end
 				RUBY
-			end
-
-			module FormWith
-				def form_with(*args, **kwargs, &block)
-					raw @_view_context.form_with(*args, **kwargs) { |form|
-						capture do
-							yield(
-								Phlex::Buffered.new(form, buffer: @_target)
-							)
-						end
-					}
-				end
 			end
 
 			module ContentFor

--- a/lib/phlex/rails/helpers.rb
+++ b/lib/phlex/rails/helpers.rb
@@ -3,28 +3,19 @@
 module Phlex
 	module Rails
 		module Helpers
-			module CSPMetaTag
-				def csp_meta_tag(**options)
-					if (output = @_view_context.csp_meta_tag(**options))
-						@_target << output
-					end
-				end
-			end
+			HELPERS = %w[csp_meta_tag csrf_meta_tags action_cable_meta_tag stylesheet_link_tag
+				favicon_link_tag preload_link_tag javascript_include_tag link_to mail_to].freeze
 
-			module CSRFMetaTags
-				def csrf_meta_tags
-					if (output = @_view_context.csrf_meta_tags)
-						@_target << output
-					end
-				end
-			end
+			HELPERS.each do |name|
+				class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
+        	# frozen_string_literal: true
 
-			module ActionCableMetaTag
-				def action_cable_meta_tag
-					if (output = @_view_context.action_cable_meta_tag)
-						@_target << output
+					def #{name}(...)
+						if (output = @_view_context.#{name}(...))
+							@_target << output
+						end
 					end
-				end
+				RUBY
 			end
 
 			module FormWith
@@ -36,38 +27,6 @@ module Phlex
 							)
 						end
 					}
-				end
-			end
-
-			module StylesheetLinkTag
-				def stylesheet_link_tag(*sources)
-					if (output = @_view_context.stylesheet_link_tag(*sources))
-						@_target << output
-					end
-				end
-			end
-
-			module FaviconLinkTag
-				def favicon_link_tag(*args)
-					if (output = @_view_context.favicon_link_tag(*args))
-						@_target << output
-					end
-				end
-			end
-
-			module PreloadLinkTag
-				def preload_link_tag(*args)
-					if (output = @_view_context.preload_link_tag(*args))
-						@_target << output
-					end
-				end
-			end
-
-			module JavaScriptIncludeTag
-				def javascript_include_tag(*sources)
-					if (output = @_view_context.javascript_include_tag(*sources))
-						@_target << output
-					end
 				end
 			end
 

--- a/lib/phlex/rails/layout.rb
+++ b/lib/phlex/rails/layout.rb
@@ -3,13 +3,13 @@
 module Phlex
 	module Rails
 		module Layout
-			include Helpers::CSPMetaTag
-			include Helpers::CSRFMetaTags
-			include Helpers::FaviconLinkTag
-			include Helpers::PreloadLinkTag
-			include Helpers::StylesheetLinkTag
-			include Helpers::ActionCableMetaTag
-			include Helpers::JavaScriptIncludeTag
+			# include Helpers::CSPMetaTag
+			# include Helpers::CSRFMetaTags
+			# include Helpers::FaviconLinkTag
+			# include Helpers::PreloadLinkTag
+			# include Helpers::StylesheetLinkTag
+			# include Helpers::ActionCableMetaTag
+			# include Helpers::JavaScriptIncludeTag
 		end
 	end
 end

--- a/test/phlex/rails/helpers.rb
+++ b/test/phlex/rails/helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Phlex::Rails::Helpers do
+	with "link_to without block" do
+		let(:output) { ArticlesController.render "show" }
+
+		it "renders the link" do
+			expect(output).to be == %(<a href="/">Go Back Home</a>)
+		end
+	end
+
+	with "link_to with block" do
+		let(:output) { ArticlesController.render "show_with_image" }
+
+		it "renders the link" do
+			expect(output).to be == %(<a class="link" href="/">Go Back Home<img src="/go/back.gif"></a>)
+		end
+	end
+end


### PR DESCRIPTION
There are quite a few regularly used Rails helpers, and having to call `helpers.*` or to delegate them, as well as having to call `raw` every time can get  a little cumbersome.

This PR replaces the current Rails::Helpers modules with dynamically defined helper method, that wrap the above. Allowing me to simply include `Phlex::Rails::Helpers` into my views.

I've only defined the existing layout helpers, along with `link_to` and `mail_to` for now. Would need to decide whether to implement every Rails helper, or perhaps break them down into groups.

If we implement them all, then including this module will include all helper methods, which I'm not sure we would want. So perhaps creating a module that corresponds to each of the `ActionView::Helpers::*` Rails modules would be a good idea.

Anyway, this new implementation makes it really easy, and for more maintainable.

- [ ] Remove `Phlex::Rails::Layout`
- [ ] Update/create tests
- [ ] Update docs