### PR TITLE
Test helpers without dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rake"
 
 gem "sus", group: [:test]
 gem "rails", group: [:test]
+gem "capybara", group: [:test]
 gem "rouge", group: [:docs]
 gem "webrick", group: [:docs]
 gem "zeitwerk", group: [:docs]

--- a/docs/pages/testing/minitest.rb
+++ b/docs/pages/testing/minitest.rb
@@ -73,16 +73,22 @@ module Pages
 
 						In addition to `css` you can use other Nokogiri finders like `xpath`, `at_css`, `at_xpath`. Read more about Nokogiri here: [https://nokogiri.org/](https://nokogiri.org/).
 
-						## Asserting with capybara (Coming Soon)
+						## Asserting with capybara
+
 						Setup capybara following the documentation: [https://github.com/teamcapybara/capybara#using-capybara-with-minitest](https://github.com/teamcapybara/capybara#using-capybara-with-minitest)
 
 						You are now able to use capybara matchers:
 
 						```ruby
 						# menu_spec.rb
+						require 'capybara/minitest'
+
 						class MenuTest < ActionView::TestCase # or Minitest::Test
+							include Phlex::TestHelpers
+							include Capybara::Minitest::Assertions
+
 							def test_it_renders_home_menu
-								render_view(MenuTest)
+								render_view(Menu.new)
 
 								assert_link "Home", href: "/"
 							end
@@ -90,12 +96,18 @@ module Pages
 						```
 
 						You can find more Capybara matchers here: [https://github.com/teamcapybara/capybara](https://github.com/teamcapybara/capybara).
+
 						### Passing blocks
 
 						You can pass blocks to `render_view`:
 
 						```ruby
+						require 'capybara/minitest'
+
 						class NavTest < ActionView::TestCase # or Minitest::Test
+							include Phlex::TestHelpers
+							include Capybara::Minitest::Assertions
+
 							def test_it_accepts_items
 								render_view(Nav.new) do |nav|
 									nav.item(href: "/products/new") { "New Product" }

--- a/lib/phlex.rb
+++ b/lib/phlex.rb
@@ -8,6 +8,9 @@ loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
 loader.ignore("#{__dir__}/generators")
 loader.ignore("#{__dir__}/install")
 loader.ignore("#{__dir__}/phlex/test_helpers.rb")
+loader.ignore("#{__dir__}/phlex/capybara/test_helpers.rb")
+loader.ignore("#{__dir__}/phlex/nokogiri/test_helpers.rb")
+loader.ignore("#{__dir__}/phlex/rails/test_helpers.rb")
 loader.inflector.inflect("html" => "HTML")
 loader.inflector.inflect("vcall" => "VCall")
 loader.inflector.inflect("fcall" => "FCall")
@@ -21,14 +24,6 @@ module Phlex
 	extend self
 
 	ATTRIBUTE_CACHE = {}
-
-	def const_missing(name)
-		if name == :Component
-			raise NameError, "👋 Phlex::Component is now Phlex::View"
-		else
-			super
-		end
-	end
 
 	def configuration
 		@configuration ||= Configuration.new

--- a/lib/phlex/capybara/test_helpers.rb
+++ b/lib/phlex/capybara/test_helpers.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+require "capybara"
+require "phlex/test_helpers"
+
 module Phlex
 	module Capybara
 		module TestHelpers
 			include Phlex::TestHelpers
 
 			def page
-				Capybara::Node::Simple.new(@output)
+				::Capybara::Node::Simple.new(@output)
 			end
 		end
 	end

--- a/lib/phlex/capybara/test_helpers.rb
+++ b/lib/phlex/capybara/test_helpers.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Phlex
+	module Capybara
+		module TestHelpers
+			include Phlex::TestHelpers
+
+			def page
+				Capybara::Node::Simple.new(@output)
+			end
+		end
+	end
+end

--- a/lib/phlex/nokogiri/nokogiri.rb
+++ b/lib/phlex/nokogiri/nokogiri.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Phlex
+	module Nokogiri
+		module TestHelpers
+			include Phlex::TestHelpers
+
+			def render(view, &block)
+				Nokogiri::HTML.fragment(super)
+			end
+		end
+	end
+end

--- a/lib/phlex/nokogiri/test_helpers.rb
+++ b/lib/phlex/nokogiri/test_helpers.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+require "nokogiri"
+require "phlex/test_helpers"
+
 module Phlex
 	module Nokogiri
 		module TestHelpers
 			include Phlex::TestHelpers
 
 			def render(view, &block)
-				Nokogiri::HTML.fragment(super)
+				::Nokogiri::HTML.fragment(super)
 			end
 		end
 	end

--- a/lib/phlex/rails/test_helpers.rb
+++ b/lib/phlex/rails/test_helpers.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "phlex/test_helpers"
+
 module Phlex
 	module Rails
 		module TestHelpers

--- a/lib/phlex/rails/test_helpers.rb
+++ b/lib/phlex/rails/test_helpers.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Phlex
+	module Rails
+		module TestHelpers
+			include Phlex::TestHelpers
+
+			def view_context
+				controller.view_context
+			end
+
+			def controller
+				@controller ||= ActionView::TestCase::TestController.new
+			end
+		end
+	end
+end

--- a/lib/phlex/test_helpers.rb
+++ b/lib/phlex/test_helpers.rb
@@ -3,7 +3,7 @@
 module Phlex
 	module TestHelpers
 		def render(view, &block)
-			@output = view.render_in(view_context, &block)
+			@output = view.call(view_context: view_context, &block)
 		end
 
 		def view_context

--- a/lib/phlex/test_helpers.rb
+++ b/lib/phlex/test_helpers.rb
@@ -4,11 +4,15 @@ module Phlex
 	module TestHelpers
 		class MissingTestDependency < StandardError; end
 
+		attr_reader :rendered
+
 		def render_view(view, &block)
-			ensure_presence_of_nokogiri
+			ensure_presence_of_nokogiri!
+
+			@page = nil # page is memoized with rendered , this will force page to be evaluated with new content
 
 			view_context = controller&.view_context
-			rendered = view.call(view_context: view_context, &block)
+			@rendered = view.call(view_context: view_context, &block)
 			Nokogiri::HTML.fragment(rendered)
 		end
 
@@ -20,12 +24,27 @@ module Phlex
 			end
 		end
 
+		def page
+			@page ||= begin
+				ensure_presence_of_capybara!
+
+				Capybara::Node::Simple.new(rendered)
+			end
+		end
+
 		private
 
-		def ensure_presence_of_nokogiri
+		def ensure_presence_of_nokogiri!
 			return if defined?(Nokogiri)
 
 			message = "You need to add `nokogiri` to your application dependencies in order to use `render_view` method"
+			raise MissingTestDependency, message
+		end
+
+		def ensure_presence_of_capybara!
+			return if defined?(Capybara)
+
+			message = "You need to add `capybara` to your application dependencies in order to assert against rendered view"
 			raise MissingTestDependency, message
 		end
 	end

--- a/lib/phlex/test_helpers.rb
+++ b/lib/phlex/test_helpers.rb
@@ -2,50 +2,12 @@
 
 module Phlex
 	module TestHelpers
-		class MissingTestDependency < StandardError; end
-
-		attr_reader :rendered
-
-		def render_view(view, &block)
-			ensure_presence_of_nokogiri!
-
-			@page = nil # page is memoized with rendered , this will force page to be evaluated with new content
-
-			view_context = controller&.view_context
-			@rendered = view.call(view_context: view_context, &block)
-			Nokogiri::HTML.fragment(rendered)
+		def render(view, &block)
+			@output = view.render_in(view_context, &block)
 		end
 
-		def controller
-			return @controller if defined?(@controller)
-
-			@controller = if defined?(ActionView::TestCase::TestController)
-				ActionView::TestCase::TestController.new
-			end
-		end
-
-		def page
-			@page ||= begin
-				ensure_presence_of_capybara!
-
-				Capybara::Node::Simple.new(rendered)
-			end
-		end
-
-		private
-
-		def ensure_presence_of_nokogiri!
-			return if defined?(Nokogiri)
-
-			message = "You need to add `nokogiri` to your application dependencies in order to use `render_view` method"
-			raise MissingTestDependency, message
-		end
-
-		def ensure_presence_of_capybara!
-			return if defined?(Capybara)
-
-			message = "You need to add `capybara` to your application dependencies in order to assert against rendered view"
-			raise MissingTestDependency, message
+		def view_context
+			nil
 		end
 	end
 end

--- a/test/phlex/capybara/test_helpers.rb
+++ b/test/phlex/capybara/test_helpers.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "phlex/capybara/test_helpers"
+
+class Example < Phlex::View
+	def template
+		h1 { "Hello" }
+	end
+end
+
+describe Phlex::Capybara::TestHelpers do
+	include Phlex::Capybara::TestHelpers
+
+	describe "#page" do
+		it "returns the rendered view as capybara node" do
+			render Example.new
+
+			expect(page).to be_a Capybara::Node::Simple
+			expect(page.all("h1").first.text).to be == "Hello"
+		end
+
+		it "memoizes the results" do
+			a, b = page, page
+			expect(a).to be == b
+		end
+	end
+end

--- a/test/phlex/nokogiri/test_helpers.rb
+++ b/test/phlex/nokogiri/test_helpers.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "phlex/nokogiri/test_helpers"
+
+class Example < Phlex::View
+	def template
+		h1 { "Hello" }
+	end
+end
+
+describe Phlex::Nokogiri::TestHelpers do
+	include Phlex::Nokogiri::TestHelpers
+
+	describe "#render" do
+		it "parses the rendered output to a nokogiri node" do
+			expect(render(Example.new)).to be_a Nokogiri::HTML::DocumentFragment
+		end
+	end
+end

--- a/test/phlex/rails/test_helpers.rb
+++ b/test/phlex/rails/test_helpers.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "phlex/rails/test_helpers"
+
+describe Phlex::Rails::TestHelpers do
+	include Phlex::Rails::TestHelpers
+
+	describe "#view_context" do
+		it "is the controller's view context" do
+			expect(view_context.controller).to be == controller
+		end
+	end
+
+	describe "#controller" do
+		it "is an ActionView::TestCase::TestController" do
+			expect(controller).to be_a ActionView::TestCase::TestController
+		end
+
+		it "is memoized" do
+			a, b = controller, controller
+			expect(a).to be == b
+		end
+	end
+end

--- a/test/phlex/test_helpers.rb
+++ b/test/phlex/test_helpers.rb
@@ -2,181 +2,36 @@
 
 require "test_helper"
 require "phlex/test_helpers"
-require "capybara"
+
+class Example < Phlex::View
+	def template(&content)
+		ul(&content)
+	end
+
+	def item(&content)
+		li(&content)
+	end
+end
 
 describe Phlex::TestHelpers do
 	include Phlex::TestHelpers
 
-	describe "#render_view" do
-		it "parses rendered string in to a nokogiri nodeset" do
-			view = Class.new(Phlex::View) do
-				def template
-					h2 { "Some title" }
-				end
-			end
-
-			output = render_view(view.new)
-
-			expect(output.class).to be == Nokogiri::HTML::DocumentFragment
+	describe "#render" do
+		it "renders the view" do
+			expect(render(Example.new)).to be == %(<ul></ul>)
 		end
 
 		it "accepts content block" do
-			nav_view = Class.new(Phlex::View) do
-				def template(&content)
-					ul(&content)
-				end
-
-				def item(&content)
-					li(&content)
-				end
-			end
-
-			output = render_view(nav_view.new) do |nav|
+			output = render(Example.new) do |nav|
 				nav.item { "Menu A" }
-				nav.item { "Menu B" }
 			end
 
-			expect(output.to_s).to be == %(<ul>\n<li>Menu A</li>\n<li>Menu B</li>\n</ul>)
+			expect(output.to_s).to be == %(<ul><li>Menu A</li></ul>)
 		end
 
-		it "uses controller view context" do
-			view = Class.new(Phlex::View) do
-				def template
-					h1 { "Hello" }
-				end
-			end
-			example = view.new
-			view_context = controller.view_context
-
-			mock(controller) do |mock|
-				mock.replace(:view_context) do
-					view_context
-				end
-			end
-
-			expect(example).to receive(:call).with(view_context: view_context)
-
-			render_view(example)
-		end
-
-		with "controller not present" do
-			it "renders without problem" do
-				expect(self).to receive(:controller).and_return(nil)
-
-				view = Class.new(Phlex::View) do
-					def template
-						h1 { "Hello" }
-					end
-				end
-
-				result = render_view(view.new)
-
-				expect(result.to_s).to be == "<h1>Hello</h1>"
-			end
-		end
-
-		with "Nokogiri missing" do
-			it "raises error" do
-				nokogiri_const = ::Nokogiri
-				Object.send :remove_const, :Nokogiri
-
-				message = "You need to add `nokogiri` to your application dependencies in order to use `render_view` method"
-
-				expect do
-					render_view(Phlex::View.new)
-				end.to raise_exception(Phlex::TestHelpers::MissingTestDependency, message: be == message)
-
-				::Nokogiri = nokogiri_const
-			end
-		end
-	end
-
-	describe "#controller" do
-		with "ActionView::TestCase::TestController defined" do
-			it "returns a new TestController instance" do
-				expect(controller).to be(:kind_of?, ActionView::TestCase::TestController)
-			end
-		end
-
-		with "ActionView::TestCase::TestController missing" do
-			it "returns nil" do
-				action_view_const = ::ActionView
-				Object.send :remove_const, :ActionView
-
-				expect(controller.nil?).to be == true
-
-				::ActionView = action_view_const
-			end
-		end
-
-		it "memoizes result" do
-			stored_controller = controller
-
-			# If memoization doesn't work, the `controller` should be a different instance
-			expect(controller).to be == stored_controller
-		end
-	end
-
-	describe "#page" do
-		it "returns rendered view as capybara node" do
-			view = Class.new(Phlex::View) do
-				def template
-					h1 { "Hello" }
-				end
-			end
-
-			render_view(view.new)
-
-			expect(page.all("h1").first.text).to be == "Hello"
-		end
-
-		it "memoizes result" do
-			view = Class.new(Phlex::View) do
-				def template
-					h1 { "Hello" }
-				end
-			end
-
-			render_view(view.new)
-
-			stored_page = page
-
-			# if memoization doesn't work, the `page` should be a different instance
-			expect(page).to be == stored_page
-		end
-
-		with "`render_view` beign called multiple times" do
-			it "returns last content rendered" do
-				first_view = Class.new(Phlex::View) do
-					def template
-						span { "First view" }
-					end
-				end
-
-				second_view = Class.new(Phlex::View) do
-					def template
-						span { "Second view" }
-					end
-				end
-
-				render_view(first_view.new)
-				render_view(second_view.new)
-
-				expect(page.all("span").first.text).to be == "Second view"
-			end
-		end
-
-		with "Capybara missing" do
-			it "raises error" do
-				capybara_const = ::Capybara
-				Object.send :remove_const, :Capybara
-
-				message = "You need to add `capybara` to your application dependencies in order to assert against rendered view"
-
-				expect { page }.to raise_exception(Phlex::TestHelpers::MissingTestDependency, message: be == message)
-
-				::Capybara = capybara_const
-			end
+		it "stores the rendered output in the @output instance variable" do
+			render Example.new
+			expect(@output).to be == %(<ul></ul>)
 		end
 	end
 end


### PR DESCRIPTION
@stephannv I haven't updated the tests or docs yet, but what do you think of this take on #278? Instead of depending on Capybara or Nokogiri or Rails, we provide basic functionality in `Phlex::TestHelpers` but you can include `Phlex::Capybara::TestHelpers` or `Phlex::Nokogiri::TestHelpers` instead, and can also include `Phlex::Rails::TestHelpers`.

You would probably combine these in your own view test helper, e.g.

```ruby
module ViewTestHelpers
  include Phlex::Rails::TestHelpers
  include Phlex::Capybara::TestHelpers
end
```

I think this provides a bit more flexibility. For example, you could easily use a gem such as [RSpec HTML Matchers](https://github.com/kucaahbe/rspec-html-matchers) if you wanted to.