### PR TITLE
feat: Before/after callbacks #259

### DIFF
--- a/docs/pages/views.rb
+++ b/docs/pages/views.rb
@@ -154,7 +154,7 @@ module Pages
 				render Markdown.new(<<~MD)
 					## Callbacks
 
-					Prepend the `Phlex::View::Callbacks` module, and if you define `#before_template` and/or `#after_callback` method in your view, they will be called immediately before and after your template is compiled.
+					Prepend the `Phlex::View::Callbacks` module, and if you define `#before_rendering_template` and/or `#after_rendering_template` method in your view, they will be called immediately before and after your template is compiled.
 				MD
 
 				render Example.new do |e|
@@ -162,7 +162,7 @@ module Pages
 						class Example < Phlex::View
       				prepend Phlex::View::Callbacks
 
-      				def before_template
+      				def before_rendering_template
 								h1 { "Hello" }
 							end
 
@@ -170,7 +170,7 @@ module Pages
 								h2 { "World" }
 							end
 
-              def after_template
+              def after_rendering_template
 								h3 { "Bye" }
 							end
       			end

--- a/docs/pages/views.rb
+++ b/docs/pages/views.rb
@@ -150,6 +150,34 @@ module Pages
 
 					e.execute "Example.new.call"
 				end
+
+				render Markdown.new(<<~MD)
+					## Callbacks
+
+					Prepend the `Phlex::View::Callbacks` module, and if you define `#before_template` and/or `#after_callback` method in your view, they will be called immediately before and after your template is compiled.
+				MD
+
+				render Example.new do |e|
+					e.tab "example.rb", <<~RUBY
+						class Example < Phlex::View
+      				prepend Phlex::View::Callbacks
+
+      				def before_template
+								h1 { "Hello" }
+							end
+
+							def template
+								h2 { "World" }
+							end
+
+              def after_template
+								h3 { "Bye" }
+							end
+      			end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
 			end
 		end
 	end

--- a/lib/phlex/view/callbacks.rb
+++ b/lib/phlex/view/callbacks.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Phlex::View::Callbacks
+	def template(&block)
+		respond_to?(:before_template) && before_template
+
+		super(&block)
+
+		respond_to?(:after_template) && after_template
+	end
+end

--- a/lib/phlex/view/callbacks.rb
+++ b/lib/phlex/view/callbacks.rb
@@ -2,10 +2,10 @@
 
 module Phlex::View::Callbacks
 	def template(&block)
-		respond_to?(:before_template) && before_template
+		before_rendering_template if respond_to?(:before_rendering_template)
 
 		super(&block)
 
-		respond_to?(:after_template) && after_template
+		after_rendering_template if respond_to?(:after_rendering_template)
 	end
 end

--- a/test/phlex/view/callbacks.rb
+++ b/test/phlex/view/callbacks.rb
@@ -9,7 +9,7 @@ describe Phlex::View do
 		view do
 			prepend Phlex::View::Callbacks
 
-			def before_template
+			def before_rendering_template
 				h1 { "Hello" }
 			end
 
@@ -17,7 +17,7 @@ describe Phlex::View do
 				h2 { "World" }
 			end
 
-			def after_template
+			def after_rendering_template
 				h3 { "Bye" }
 			end
 		end

--- a/test/phlex/view/callbacks.rb
+++ b/test/phlex/view/callbacks.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe Phlex::View do
+	extend ViewHelper
+
+	with "callbacks" do
+		view do
+			prepend Phlex::View::Callbacks
+
+			def before_template
+				h1 { "Hello" }
+			end
+
+			def template
+				h2 { "World" }
+			end
+
+			def after_template
+				h3 { "Bye" }
+			end
+		end
+
+		it "calls before and after template" do
+			expect(output).to be == "<h1>Hello</h1><h2>World</h2><h3>Bye</h3>"
+		end
+	end
+end


### PR DESCRIPTION
Simply prepend `Phlex::View::Callbacks` to any view, and define `#before_template` and/or `#after_template`.