### PR TITLE
feat: Revert _attributes name change in favour of an explicitly defined process_attributes

### DIFF
--- a/docs/pages/templates.rb
+++ b/docs/pages/templates.rb
@@ -77,6 +77,32 @@ module Pages
 				end
 
 				render Markdown.new(<<~MD)
+					## Processing Attributes
+
+					Sometimes you may want to process, modify, or simply be able to read the attributes that tags are given. For example, you may want to assign an `id` attribute to every tag, or even use the `tokens` helper to automatically tokenize the `class` attribute.
+
+					Simply define a `process_attributes` method in your view. This method will be called on each tag, with the attributes as keyword arguments, and should return a Hash of the attributes.
+				MD
+
+				render Example.new do |e|
+					e.tab "example.rb", <<~RUBY
+						class Example < Phlex::View
+							def template
+								h1(class: 'title') { "Hello" }
+							end
+
+							def process_attributes(**attributes)
+								attributes.tap do |attrs|
+									attrs[:id] = SecureRandom.uuid
+								end
+							end
+						end
+					RUBY
+
+					e.execute "Example.new.call"
+				end
+
+				render Markdown.new(<<~MD)
 					## The template tag
 
 					Because the `template` method is used to define the view template itself, you'll need to use the method `template_tag` if you want to to render an HTML `<template>` tag.

--- a/docs/pages/views.rb
+++ b/docs/pages/views.rb
@@ -154,7 +154,7 @@ module Pages
 				render Markdown.new(<<~MD)
 					## Callbacks
 
-					Prepend the `Phlex::View::Callbacks` module, and if you define `#before_rendering_template` and/or `#after_rendering_template` method in your view, they will be called immediately before and after your template is compiled.
+					Prepend the `Phlex::View::Callbacks` module, and if you define `#before_rendering_template` and/or `#after_rendering_template` method in your view, they will be called immediately before and after your template is rendered.
 				MD
 
 				render Example.new do |e|

--- a/lib/phlex/compiler/generators/element.rb
+++ b/lib/phlex/compiler/generators/element.rb
@@ -18,7 +18,7 @@ module Phlex
 
 					if @node.arguments&.parts&.any?
 						@formatter.chain_append do |f|
-							f.text "process_attributes("
+							f.text "_attributes("
 							@node.arguments.format(@formatter)
 							f.text ")"
 						end

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -137,11 +137,11 @@ module Phlex
 
           if attributes.length > 0
             if block_given?
-              @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || process_attributes(**attributes)) << ">"
+              @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(**attributes)) << ">"
               yield_content(&block)
               @_target << "</#{tag}>"
             else
-              @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || process_attributes(**attributes)) << "></#{tag}>"
+              @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(**attributes)) << "></#{tag}>"
             end
           else
             if block_given?
@@ -164,7 +164,7 @@ module Phlex
 
         def #{element}(**attributes)
           if attributes.length > 0
-            @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || process_attributes(**attributes)) << ">"
+            @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(**attributes)) << ">"
           else
             @_target << "<#{tag}>"
           end

--- a/lib/phlex/view.rb
+++ b/lib/phlex/view.rb
@@ -182,9 +182,17 @@ module Phlex
 			@_view_context
 		end
 
-		def process_attributes(buffer = +"", **attributes)
+		def _attributes(buffer = +"", **attributes)
 			if attributes[:href]&.start_with?(/\s*javascript/)
 				attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "")
+			end
+
+			if respond_to?(:process_attributes)
+				attributes = process_attributes(**attributes)
+
+				unless attributes.is_a?(Hash)
+					raise "`#{self.class.name}#process_attributes` must return a hash of attributes"
+				end
 			end
 
 			_build_attributes(attributes, buffer: buffer)

--- a/test/phlex/compilation/standard_element.rb
+++ b/test/phlex/compilation/standard_element.rb
@@ -26,7 +26,7 @@ describe Phlex::Compiler do
 
 		expected = <<~RUBY
 			def template
-				@_target << "<h1" << process_attributes(class: "font-bold") << "></h1>"
+				@_target << "<h1" << _attributes(class: "font-bold") << "></h1>"
 			end
 		RUBY
 
@@ -53,7 +53,7 @@ describe Phlex::Compiler do
 
 		expect(output.first).to be == <<~RUBY
 			def template
-				@_target << "<h1" << process_attributes(class: "font-bold") << ">Hi</h1>"
+				@_target << "<h1" << _attributes(class: "font-bold") << ">Hi</h1>"
 			end
 		RUBY
 	end
@@ -78,7 +78,7 @@ describe Phlex::Compiler do
 
 		expected = <<~RUBY
 			def template
-				@_target << "<h1" << process_attributes(class: "font-bold") << ">Hi</h1>"
+				@_target << "<h1" << _attributes(class: "font-bold") << ">Hi</h1>"
 			end
 		RUBY
 

--- a/test/phlex/compilation/void_element.rb
+++ b/test/phlex/compilation/void_element.rb
@@ -26,7 +26,7 @@ describe Phlex::Compiler do
 
 		expected = <<~RUBY
 			def template
-				@_target << "<img" << process_attributes(class: "a b c") << ">"
+				@_target << "<img" << _attributes(class: "a b c") << ">"
 			end
 		RUBY
 

--- a/test/phlex/view/attributes.rb
+++ b/test/phlex/view/attributes.rb
@@ -17,6 +17,45 @@ describe Phlex::View do
 		end
 	end
 
+	with "process_attributes" do
+		view do
+			def template
+				div class: "header"
+			end
+
+			def process_attributes(**attributes)
+				attributes.tap do |attrs|
+					attrs[:class] = "#{attrs[:class]}123abc" if attributes.key?(:class)
+				end
+			end
+		end
+
+		it "calls the attribute method" do
+			expect(output).to be == %(<div class="header123abc"></div>)
+		end
+	end
+
+	with "process_attributes returning no hash" do
+		view do
+			def template
+				div class: "header"
+			end
+
+			def process_attributes(**attributes)
+				nil
+			end
+		end
+
+		it "raises when return value is not a Hash" do
+			expect do
+				output
+			end.to raise_exception(
+				RuntimeError,
+				message: be =~ /process_attributes` must return a hash of attributes/
+			)
+		end
+	end
+
 	if RUBY_ENGINE == "ruby"
 		with "unique tag attributes" do
 			view do


### PR DESCRIPTION
Resolves #301 and #300

Also added a safeguard that `process_attributes` should return a Hash, raising a `RuntimeError` if not. Because returning nothing or anything else will break the internet! ;)