### PR TITLE
Remove iteration details from collections

### DIFF
--- a/docs/pages/library/collections.rb
+++ b/docs/pages/library/collections.rb
@@ -32,16 +32,6 @@ module Pages
 						end
 						```
 
-						You can also access the predicates `first?` and `last?` and the instance variables `@index`, `@position` and `@collection`.
-
-						```ruby
-						def item_template
-							li **classes(first?: "border-t") do
-								"\#{@position}/\#{@collection.size} \#{@item}"
-							end
-						end
-						```
-
 						## Rendering a collection
 
 						Putting it all together, we can create a `List` view that renders each item in an `<li>`, all wrapped up in an outer `<ul>`.
@@ -59,9 +49,7 @@ module Pages
 								end
 
 								def item_template
-									li **classes(first?: "font-bold") do
-										"(\#{@position}/\#{@collection.size}) \#{@item}"
-									end
+									li { @item }
 								end
 							end
 						RUBY
@@ -86,12 +74,6 @@ module Pages
 
 						```ruby
 						render List.new(item: "A")
-						```
-
-						If you've used any of the iteration variables and predicates — `first?`, `last?`, `@position`, `@index`, etc. you'll need to pass these manually to simulate this item's position.
-
-						```ruby
-						render List.new(item: "A", first: true, position: 1)
 						```
 					MD
 				end

--- a/lib/phlex/collection.rb
+++ b/lib/phlex/collection.rb
@@ -12,11 +12,7 @@ module Phlex
 		end
 
 		def template
-			if @item
-				item_template
-			else
-				collection_template { yield_items }
-			end
+			@item ? item_template : collection_template { yield_items }
 		end
 
 		private
@@ -26,33 +22,12 @@ module Phlex
 				raise ArgumentError, "You can only yield_items when rendering a collection. You are currently rendering an item."
 			end
 
-			@collection.each_with_index do |item, index|
+			@collection.each do |item|
 				@item = item
-				@index = index
-				@position = (index + 1)
-				@first = (index == 0)
-				@last = (@position == @collection.size)
-
 				item_template
 			end
 
 			@item = nil
-			@index = nil
-			@first = nil
-			@last = nil
-			@position = nil
-		end
-
-		def first?
-			raise ArgumentError unless @item
-
-			!!@first
-		end
-
-		def last?
-			raise ArgumentError unless @item
-
-			!!@last
 		end
 	end
 end


### PR DESCRIPTION
It was fun to experiment with these, but I’m of quite a strong opinion that they should be implemented using CSS counters and nth selectors instead. This way, state doesn't need to be passed in when rendering an item.