### PR TITLE
Remove `process_attributes` feature

### DIFF
--- a/docs/pages/templates.rb
+++ b/docs/pages/templates.rb
@@ -77,32 +77,6 @@ module Pages
 				end
 
 				render Markdown.new(<<~MD)
-					## Processing Attributes
-
-					Sometimes you may want to process, modify, or simply be able to read the attributes that tags are given. For example, you may want to assign an `id` attribute to every tag, or even use the `tokens` helper to automatically tokenize the `class` attribute.
-
-					Simply define a `process_attributes` method in your view. This method will be called on each tag, with the attributes as keyword arguments, and should return a Hash of the attributes.
-				MD
-
-				render Example.new do |e|
-					e.tab "example.rb", <<~RUBY
-						class Example < Phlex::View
-							def template
-								h1(class: 'title') { "Hello" }
-							end
-
-							def process_attributes(**attributes)
-								attributes.tap do |attrs|
-									attrs[:id] = SecureRandom.uuid
-								end
-							end
-						end
-					RUBY
-
-					e.execute "Example.new.call"
-				end
-
-				render Markdown.new(<<~MD)
 					## The template tag
 
 					Because the `template` method is used to define the view template itself, you'll need to use the method `template_tag` if you want to to render an HTML `<template>` tag.

--- a/lib/phlex/view.rb
+++ b/lib/phlex/view.rb
@@ -152,19 +152,12 @@ module Phlex
 			@_view_context
 		end
 
-		def _attributes(buffer = +"", **attributes)
+		def _attributes(**attributes)
 			if attributes[:href]&.start_with?(/\s*javascript/)
 				attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "")
 			end
 
-			if respond_to?(:process_attributes)
-				attributes = process_attributes(**attributes)
-
-				unless attributes.is_a?(Hash)
-					raise "`#{self.class.name}#process_attributes` must return a hash of attributes"
-				end
-			end
-
+			buffer = +""
 			_build_attributes(attributes, buffer: buffer)
 
 			unless self.class.rendered_at_least_once

--- a/test/phlex/view/attributes.rb
+++ b/test/phlex/view/attributes.rb
@@ -15,45 +15,6 @@ describe Phlex::View do
 		end
 	end
 
-	with "process_attributes" do
-		view do
-			def template
-				div class: "header"
-			end
-
-			def process_attributes(**attributes)
-				attributes.tap do |attrs|
-					attrs[:class] = "#{attrs[:class]}123abc" if attributes.key?(:class)
-				end
-			end
-		end
-
-		it "calls the attribute method" do
-			expect(output).to be == %(<div class="header123abc"></div>)
-		end
-	end
-
-	with "process_attributes returning no hash" do
-		view do
-			def template
-				div class: "header"
-			end
-
-			def process_attributes(**attributes)
-				nil
-			end
-		end
-
-		it "raises when return value is not a Hash" do
-			expect do
-				output
-			end.to raise_exception(
-				RuntimeError,
-				message: be =~ /process_attributes` must return a hash of attributes/
-			)
-		end
-	end
-
 	if RUBY_ENGINE == "ruby"
 		with "unique tag attributes" do
 			view do


### PR DESCRIPTION
@joelmoss I’m really sorry but I have to remove this feature for now as it's broken by the caching. I tried to change attribute caching to be per-class, but the performance is so much worse because we have to use `self.class.attribute_cache` or `Phlex::ATTRIBUTE_CACHE[self.class.name]` and both require multiple method calls. I’ve got some ideas about how we might be able to put it back in with a mixin, but it's got to go for now.

It would be quite easy to support a global attribute processing function so that might be an option, e.g.

```ruby
Phlex.configure do |config|
  config.process_attributes do |attributes|
    bla
  end
end
```