### PR TITLE
Fix list style in documentation

### DIFF
--- a/docs/assets/application.css
+++ b/docs/assets/application.css
@@ -24,3 +24,11 @@ pre { tab-size: 2; }
 p {
   @apply my-5
 }
+
+ol,
+ul,
+menu {
+  list-style: revert;
+  margin: 0 0 0 1rem;
+  padding: 0 0 0 1rem;
+}

--- a/docs/pages/rails/getting_started.rb
+++ b/docs/pages/rails/getting_started.rb
@@ -23,7 +23,7 @@ module Pages
 						This script will:
 
 						1. update `config/application.rb` to include `/app` in your auto-load paths;
-						2. generate `views/application_view.rb`
+						2. generate `views/application_view.rb`.
 
 						Like `ApplicationRecord`, `ApplicationView` is your base view which all your other views should inherit from.
 


### PR DESCRIPTION
The current list style could be improved in the docs For some reason Tailwind removes the list style by default from lists making them hard to read. This PR adds default styling for lists back. You can have a look at the [getting started => setup](https://www.phlex.fun/rails/getting-started/) section of the documentation for Rails.

Before the change:

![Screen Shot 2022-11-02 at 19 18 12](https://user-images.githubusercontent.com/33979976/199570630-bb4e73ab-8d9e-4696-aa31-91a1c0ed32cd.png)

After the change: 

![Screen Shot 2022-11-02 at 19 19 00](https://user-images.githubusercontent.com/33979976/199570584-25cf00fe-335b-46a2-bf9c-c2d000556792.png)