### PR TITLE
Generator task for Rails controller with Phlex views

### DIFF
--- a/lib/generators/phlex/controller/USAGE
+++ b/lib/generators/phlex/controller/USAGE
@@ -2,9 +2,9 @@ Description:
   Generates a Rails controller with Phlex views for the supplied actions
 
 Example:
-  rails generate phlex:controller Home index show
+  rails generate phlex:controller Articles index show
 
 This will create:
-  app/controllers/home.rb
-  app/views/home/index.rb
-  app/views/home/show.rb
+  app/controllers/articles_controller.rb
+  app/views/articles/index.rb
+  app/views/articles/show.rb

--- a/lib/generators/phlex/controller/USAGE
+++ b/lib/generators/phlex/controller/USAGE
@@ -1,0 +1,10 @@
+Description:
+  Generates a Rails controller with Phlex views for the supplied actions
+
+Example:
+  rails generate phlex:controller Home index show
+
+This will create:
+  app/controllers/home.rb
+  app/views/home/index.rb
+  app/views/home/show.rb

--- a/lib/generators/phlex/controller/controller_generator.rb
+++ b/lib/generators/phlex/controller/controller_generator.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Phlex
+	module Generators
+		class ControllerGenerator < ::Rails::Generators::NamedBase # :nodoc:
+			source_root File.expand_path("templates", __dir__)
+
+			argument :actions, type: :array, default: [], banner: "action action"
+			class_option :skip_routes, type: :boolean, desc: "Don't add routes to config/routes.rb."
+			class_option :parent, type: :string, default: "ApplicationController", desc: "The parent class for the generated controller"
+
+			check_class_collision suffix: "Controller"
+
+			def create_controller_files
+				template "controller.rb.erb", File.join("app/controllers", class_path, "#{file_name}_controller.rb")
+			end
+
+			def copy_view_files
+				base_path = File.join("app/views", class_path, file_name)
+				empty_directory base_path
+
+				actions.each do |action|
+					Rails::Generators.invoke("phlex:view", [remove_possible_suffix(name) + "/" + action])
+				end
+			end
+
+			def add_routes
+				return if options[:skip_routes]
+				return if actions.empty?
+
+				routing_code = actions.map { |action| "get '#{file_name}/#{action}'" }.join("\n")
+				route routing_code, namespace: regular_class_path
+			end
+
+			hook_for :test_framework, as: :controller do |generator|
+				invoke generator, [remove_possible_suffix(name), actions]
+			end
+
+			private
+
+			def parent_class_name
+				options[:parent]
+			end
+
+			def file_name
+				@_file_name ||= remove_possible_suffix(super)
+			end
+
+			def remove_possible_suffix(name)
+				name.sub(/_?controller$/i, "")
+			end
+		end
+	end
+end

--- a/lib/generators/phlex/controller/templates/controller.rb.erb
+++ b/lib/generators/phlex/controller/templates/controller.rb.erb
@@ -1,0 +1,10 @@
+<% module_namespacing do -%>
+class <%= class_name %>Controller < <%= parent_class_name.classify %>
+<% actions.each do |action| -%>
+  def <%= action %>
+    render Views::<%= class_name %>::<%= action.camelize %>.new
+  end
+<%= "\n" unless action == actions.last -%>
+<% end -%>
+end
+<% end -%>

--- a/lib/generators/phlex/controller/templates/view.rb.erb
+++ b/lib/generators/phlex/controller/templates/view.rb.erb
@@ -1,0 +1,14 @@
+<% module_namespacing do -%>
+module Views
+  class <%= class_name %>::<%= @action.camelize %> < Phlex::HTML
+    include ApplicationView
+
+    def template
+      <%= "# " unless @has_layout %>render Layout.new(title: "<%= class_name.gsub("::", " ").titlecase %> - <%= @action.titlecase %>") do
+        h1 { "<%= class_name %>#<%= @action %>" }
+        p { "Find me in <%= @path %>" }
+      <%= "# " unless @has_layout %>end
+    end
+  end
+end
+<% end %>

--- a/lib/generators/phlex/view/templates/view.rb.erb
+++ b/lib/generators/phlex/view/templates/view.rb.erb
@@ -4,6 +4,10 @@ module Views
     include ApplicationView
 
     def template
+      <%= "# " unless @layout %>render Layout.new(title: "<%= class_name.gsub("::", " ").titlecase %>") do
+        h1 { "<%= class_name %>" }
+        p { "Find me in <%= @path %>" }
+      <%= "# " unless @layout %>end
     end
   end
 end

--- a/lib/generators/phlex/view/view_generator.rb
+++ b/lib/generators/phlex/view/view_generator.rb
@@ -6,7 +6,15 @@ module Phlex
 			source_root File.expand_path("templates", __dir__)
 
 			def create_view
-				template "view.rb.erb", File.join("app/views", class_path, "#{file_name}.rb")
+				@layout = layout
+				@path = File.join("app/views", class_path, "#{file_name}.rb")
+				template "view.rb.erb", @path
+			end
+
+			private
+
+			def layout
+				Rails.root.join("app/views/layout.rb").exist?
 			end
 		end
 	end


### PR DESCRIPTION
As mentioned [here](https://github.com/joeldrapper/phlex/discussions/235#discussioncomment-3852112), it seems desirable to be able to emulate the Rails controller generator:

`rails generate controller Home index about`

This PR provides a single generator that creates a Rails controller with routes, actions, and the set of Phlex views. Each action renders the view, and the default content of the view matches that of the default ERB template for an action:

`rails generate phlex:controller Home index about`

This generates:

```ruby
# app/controllers/home_controller.rb
class HomeController < ApplicationController
  def index
    render Views::Nice::Index.new
  end

  def about
    render Views::Nice::About.new
  end
end

# app/views/home/index.rb - if app/views/layout.rb exists
module Views
  class Home::Index < Phlex::HTML
    include ApplicationView

    def template
      render Layout.new(title: "Home - Index") do
        h1 { "Home#index" }
        p { "Find me in app/views/home/index.rb" }
      end
    end
  end
end

# app/views/home/about.rb - if app/views/layout.rb does not exist
module Views
  class Home::About < Phlex::HTML
    include ApplicationView

    def template
      # render Layout.new(title: "Home - About") do
        h1 { "Home#about" }
        p { "Find me in app/views/home/about.rb" }
      # end
    end
  end
end

```

I hope this is useful, please let me know if there's anything that could be improved. Did you want a commit updating the docs too?

If #279 gets merged I'll have to come back and check that view file tests are created alongside the controller.

(I ran the tests btw, but I'm getting the same two failures before and after these changes)
