### PR TITLE
Phlex::Markdown [EXPERIMENTAL]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :docs do
 	gem "filewatcher"
 	gem "htmlbeautifier"
 	gem "redcarpet"
+	gem "markly"
 	gem "webrick"
 	gem "rouge"
 end

--- a/docs/components/heading.rb
+++ b/docs/components/heading.rb
@@ -3,7 +3,7 @@
 module Components
 	class Heading < Phlex::HTML
 		def template(&block)
-			h2(class: "text-2xl font-semibold mt-10 mb-5") { unsafe_raw(&block) }
+			h2(class: "text-2xl font-semibold mt-10 mb-5", &block)
 		end
 	end
 end

--- a/docs/components/markdown.rb
+++ b/docs/components/markdown.rb
@@ -1,40 +1,21 @@
 # frozen_string_literal: true
 
 module Components
-	class Markdown < Phlex::HTML
-		class Render < Redcarpet::Render::HTML
-			include Redcarpet::Render::SmartyPants
-
-			def header(text, level)
-				case level
-				when 1
-					Title.new.call { CGI.unescapeHTML(text) }
-				else
-					Heading.new.call { CGI.unescapeHTML(text) }
-				end
-			end
-
-			def codespan(code)
-				CodeSpan.new.call { code }
-			end
-
-			def block_code(code, language)
-				CodeBlock.new(code.gsub(/(?:^|\G) {4}/m, "	"), syntax: language).call
-			end
-
-			def html_escape(input)
-				input
-			end
+	class Markdown < Phlex::Markdown
+		def code(&content)
+			render CodeSpan.new, &content
 		end
 
-		MARKDOWN = Redcarpet::Markdown.new(Render.new, filter_html: false, autolink: true, fenced_code_blocks: true, tables: true, highlight: true, escape_html: false)
-
-		def initialize(content)
-			@content = content
+		def code_block(code, language:)
+			render CodeBlock.new(code.gsub(/(?:^|\G) {4}/m, "	"), syntax: language)
 		end
 
-		def template
-			unsafe_raw MARKDOWN.render(@content)
+		def h1(&content)
+			render Title.new, &content
+		end
+
+		def h2(&content)
+			render Heading.new, &content
 		end
 	end
 end

--- a/docs/components/title.rb
+++ b/docs/components/title.rb
@@ -3,7 +3,7 @@
 module Components
 	class Title < Phlex::HTML
 		def template(&block)
-			h1(class: "text-3xl font-semibold my-5") { unsafe_raw(&block) }
+			h1(class: "text-3xl font-semibold my-5", &block)
 		end
 	end
 end

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -272,6 +272,7 @@ module Phlex
 			yield
 
 			@_target = original_buffer
+
 			new_buffer.html_safe
 		end
 

--- a/lib/phlex/markdown.rb
+++ b/lib/phlex/markdown.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "markly"
+
+module Phlex
+	class Markdown < Phlex::HTML
+		def initialize(content)
+			@content = content
+		end
+
+		def template
+			visit(doc)
+		end
+
+		private
+
+		def doc
+			Markly.parse(@content)
+		end
+
+		def visit(node)
+			return if node.nil?
+
+			case node.type
+			in :document | :softbreak
+				visit_children(node)
+			in :text
+				text(node.string_content)
+			in :header
+				case node.header_level
+					in 1 then h1 { visit_children(node) }
+					in 2 then h2 { visit_children(node) }
+					in 3 then h3 { visit_children(node) }
+					in 4 then h4 { visit_children(node) }
+					in 5 then h5 { visit_children(node) }
+					in 6 then h6 { visit_children(node) }
+				end
+			in :paragraph
+				p { visit_children(node) }
+			in :link
+				a(href: node.url) { visit_children(node) }
+			in :emph
+				em { visit_children(node) }
+			in :strong
+				strong { visit_children(node) }
+			in :list
+				case node.list_type
+					in :ordered_list then ol { visit_children(node) }
+					in :bullet_list then ul { visit_children(node) }
+				end
+			in :list_item
+				li { visit_children(node) }
+			in :code
+				code { text(node.string_content) }
+			in :code_block
+				code_block(node.string_content, language: node.fence_info) do |**attributes|
+					pre(**attributes) { text(node.string_content) }
+				end
+			end
+		end
+
+		def code_block(code, language:)
+			yield
+		end
+
+		def visit_children(node)
+			node.each { |c| visit(c) }
+		end
+	end
+end


### PR DESCRIPTION
An abstract `Phlex::Markdown` component can be initialised with a Markdown document and renders to HTML. You can subclass `Phlex::Markdown`, overriding methods like `h1`, `code`, `code_block` to customise the output.