### PR TITLE
Allow `Phlex::Turbo::Stream` element to take arbitrary attributes

### DIFF
--- a/lib/phlex/turbo/stream.rb
+++ b/lib/phlex/turbo/stream.rb
@@ -5,13 +5,13 @@ module Phlex
 		class Stream < Phlex::HTML
 			register_element :turbo_stream
 
-			def initialize(action:, target:)
+			def initialize(action:, **attributes)
 				@action = action
-				@target = target
+				@attributes = attributes
 			end
 
 			def template(&content)
-				turbo_stream(action: @action, target: @target, &content)
+				turbo_stream(action: @action, **@attributes, &content)
 			end
 		end
 	end

--- a/test/phlex/view/turbo/stream.rb
+++ b/test/phlex/view/turbo/stream.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+describe Phlex::Turbo::Stream do
+	extend ViewHelper
+
+	with "with action and target" do
+		view do
+			def template
+				render Phlex::Turbo::Stream.new(action: "replace", target: "users")
+			end
+		end
+
+		it "produces the correct markup" do
+			expect(output).to be ==
+				"<turbo-stream action=\"replace\" target=\"users\"></turbo-stream>"
+		end
+	end
+
+	with "custom action and additional attribute" do
+		view do
+			def template
+				render Phlex::Turbo::Stream.new(action: "custom-action", message: "Hello world")
+			end
+		end
+
+		it "produces the correct markup" do
+			expect(output).to be ==
+				"<turbo-stream action=\"custom-action\" message=\"Hello world\"></turbo-stream>"
+		end
+	end
+
+	with "custom action, target and template content" do
+		view do
+			def template
+				render Phlex::Turbo::Stream.new(action: "custom-action") do
+					template_tag { "Hello World" }
+				end
+			end
+		end
+
+		it "produces the correct markup" do
+			expect(output).to be ==
+				"<turbo-stream action=\"custom-action\"><template>Hello World</template></turbo-stream>"
+		end
+	end
+end


### PR DESCRIPTION
With the Introduction of Custom Turbo Stream Actions it's not mandatory to always just pass the `action` and `target` attributes on the `<turbo-stream>` element. 

Since you can write actions which don't target any elements you also don't need to specify the `target` or `targets` attribute (right now with Phlex `0.5` you also wouldn't be able to pass over a `targets` attribute).

Additionally, you need to be able to pass any attribute to the `<turbo-stream>` element so you can use custom attributes in your custom action.

For more context: https://github.com/hotwired/turbo-rails/pull/375 and https://github.com/hotwired/turbo-rails/pull/373