### PR TITLE
Add missing markdown nodes

### DIFF
--- a/phlex/lib/phlex/markdown.rb
+++ b/phlex/lib/phlex/markdown.rb
@@ -62,6 +62,10 @@ module Phlex
 				code_block(node.string_content, language: node.fence_info) do |**attributes|
 					pre(**attributes) { text(node.string_content) }
 				end
+			in :hrule
+				hr
+			in :blockquote
+				blockquote { visit_children(node)}
 			end
 		end
 

--- a/phlex/lib/phlex/markdown.rb
+++ b/phlex/lib/phlex/markdown.rb
@@ -65,7 +65,7 @@ module Phlex
 			in :hrule
 				hr
 			in :blockquote
-				blockquote { visit_children(node)}
+				blockquote { visit_children(node) }
 			end
 		end
 


### PR DESCRIPTION
Missing a few elements from https://gist.githubusercontent.com/quanticle/7be19a638f20bb55686f3d154f28fd4e/raw/3f2fc3faeb54a83424cc189bd9dd91161f5524a7/large_markdown.md