### PR TITLE
Add `around_template` hook

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -160,11 +160,15 @@ module Phlex
 			@_parent = parent
 			@output_buffer = self
 
-			template(&block)
+			around_template { template(&block) }
 
 			self.class.rendered_at_least_once ||= true
 
 			buffer
+		end
+
+		def around_template
+			yield
 		end
 
 		def rendered?

--- a/test/phlex/view/around_template.rb
+++ b/test/phlex/view/around_template.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe Phlex::HTML do
+	extend ViewHelper
+
+	with "around_template hook" do
+		view do
+			def around_template
+				h1 { "Before" }
+				super
+				h3 { "After" }
+			end
+
+			def template
+				h2 { "Hello" }
+			end
+		end
+
+		it "wraps the template" do
+			expect(output).to be == "<h1>Before</h1><h2>Hello</h2><h3>After</h3>"
+		end
+	end
+end


### PR DESCRIPTION
Adding an `around_template` hook to `Phlex::HTML` which will allow abstract views to wrap the `template` without forcing users to call `super` from it.

For example, we could make an abstract `Phlex::Form` view that wraps the template in a `form` and inserts a hidden authenticity token field.

```ruby
class Phlex::Form
  def around_template(&)
    form do
      authenticity_token_field
      super
    end
  end

  ...
end
```

When inheriting from this abstract view, we only need to define `template` and don’t need to remember to call `super`.

```ruby
class MyForm < Phlex::Form
  def template
    textarea name: "content"
    input type: "submit", value: "Toot!"
  end
end