### PR TITLE
Use `around_template` hook for callbacks

### DIFF
--- a/lib/phlex/html/callbacks.rb
+++ b/lib/phlex/html/callbacks.rb
@@ -1,11 +1,21 @@
 # frozen_string_literal: true
 
 module Phlex::HTML::Callbacks
-	def template(&block)
-		before_rendering_template if respond_to?(:before_rendering_template)
+	def self.prepended(mod)
+		raise "Phlex::HTML::Callbacks should be included rather than prepended."
+	end
 
+	def around_template(&block)
+		before_rendering_template
 		super
+		after_rendering_template
+	end
 
-		after_rendering_template if respond_to?(:after_rendering_template)
+	def before_rendering_template
+		nil
+	end
+
+	def after_rendering_template
+		nil
 	end
 end

--- a/test/phlex/view/callbacks.rb
+++ b/test/phlex/view/callbacks.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "callbacks" do
 		view do
-			prepend Phlex::HTML::Callbacks
+			include Phlex::HTML::Callbacks
 
 			def before_rendering_template
 				h1 { "Hello" }


### PR DESCRIPTION
Switch to using the `around_template` method for `Phlex::Callbacks`. This means we don't need to use `prepend` and patch the main `template` method. We can also define the `before_rendering_template` and `after_rendering_template` to return `nil` by default and just call them rather than checking if they’re defined first, saving time.