### PR TITLE
Automatically yield content

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -145,7 +145,7 @@ module Phlex
 			@_parent = parent
 			@output_buffer = self
 
-			around_template { template(&block) }
+			around_template { template { yield_content(&block) } }
 
 			self.class.rendered_at_least_once ||= true
 

--- a/test/phlex/view/content.rb
+++ b/test/phlex/view/content.rb
@@ -6,14 +6,14 @@ describe Phlex::HTML do
 	with "content" do
 		view do
 			def template(&block)
-				div do
-					yield_content(&block)
-				end
+				h1 { "Before" }
+				yield
+				h2 { "After" }
 			end
 		end
 
 		it "renders text content" do
-			expect(example.call { "Hi" }).to be == "<div>Hi</div>"
+			expect(example.call { "Hi" }).to be == "<h1>Before</h1>Hi<h2>After</h2>"
 		end
 	end
 end


### PR DESCRIPTION
There should be no need to use the `yield_content` method directly anymore. A simple `yield` is fine. Blocks passed to HTML elements are already wrapped in `yield_content` and this change does the same for the block passed to `template`.