### PR TITLE
`text` fallback to `to_s`

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -183,14 +183,13 @@ module Phlex
 		end
 
 		def text(content)
-			case content
-			when String
-				@_target << ERB::Util.html_escape(content)
-			when Symbol
-				@_target << ERB::Util.html_escape(content.name)
-			when Integer, Float
-				@_target << ERB::Util.html_escape(content.to_s)
-			end
+			@_target << ERB::Util.html_escape(
+				case content
+					when String then content
+					when Symbol then content.name
+					else content.to_s
+				end
+			)
 
 			nil
 		end


### PR DESCRIPTION
If someone is intentionally outputting text, we should fallback to `to_s`.

Closes #393 