### PR TITLE
Introduce object formatters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,8 @@ Layout/CaseIndentation:
 Style/StringConcatenation:
   Enabled: false
 
+Style/ClassVars:
+  Enabled: false
 
 
 Security/Eval:


### PR DESCRIPTION
Object formatters allow you to define formatters for specific object types.

```ruby
class A < Phlex::HTML
  define_formatter(Date) { |value| value.strftime("%d/%m/%y") }

  def template
    h1 { Date.today }
  end
end
```

The output would be
```html
<h1>27/11/22</h1>
```

1. The formatters are inherited but can also be overridden by subclasses
3. They match exactly against `object.class` and do not use case equality (`===`) for performance