### PR TITLE
`format_object` method

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -179,7 +179,8 @@ module Phlex
 				case content
 					when String then content
 					when Symbol then content.name
-					else content.to_s
+					when Integer, Float then content.to_s
+					else format_object(content) || content.to_s
 				end
 			)
 
@@ -234,6 +235,10 @@ module Phlex
 			true
 		end
 
+		private def format_object(oject)
+			nil
+		end
+
 		private def around_template
 			before_template
 			yield
@@ -263,6 +268,10 @@ module Phlex
 					@_target << ERB::Util.html_escape(content.name)
 				when Integer, Float
 					@_target << ERB::Util.html_escape(content.to_s)
+				else
+					if (formatted_object = format_object(content))
+						@_target << ERB::Util.html_escape(formatted_object)
+					end
 				end
 			end
 

--- a/test/phlex/view/format_object.rb
+++ b/test/phlex/view/format_object.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "date"
+
+class Example < Phlex::HTML
+	def template
+		h1 { Date.today }
+	end
+
+	private def format_object(object)
+		case object
+			when Date then object.strftime("%d/%m/%y")
+			else super
+		end
+	end
+end
+
+describe Phlex::HTML do
+	it "supports formatting objects" do
+		expect(Example.new.call).to be == "<h1>28/11/22</h1>"
+	end
+end


### PR DESCRIPTION
A simpler take on #397, allows you to define object formatters like this.

```ruby
def format_object(object)
  case object
  when Date
    object.strftime("%d/%m/%y")
  when Money
    object.format
  else
    super
  end
end
```

The interface isn’t as nice, but:

1. it gets inheritance right when you call `super` in the `else` condition;
2. you can easily define `format_object` in a module, such as `ApplicationView`;
3. it's fast; and
4. you can use case equality or pattern matching.