### PR TITLE
Just render instance of class when given a class

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -151,10 +151,13 @@ module Phlex
 		end
 
 		def render(renderable, *args, **kwargs, &block)
-			if renderable.is_a?(Phlex::HTML)
+			case renderable
+			when Phlex::HTML
 				renderable.call(@_target, view_context: @_view_context, parent: self, &block)
-			elsif renderable.is_a?(Class) && renderable < Phlex::HTML
-				raise ArgumentError, "You tried to render the Phlex view class: #{renderable.name} but you probably meant to render an instance of that class instead."
+			when Class
+				if renderable < Phlex::HTML
+					renderable.new.call(@_target, view_context: @_view_context, parent: self, &block)
+				end
 			else
 				raise ArgumentError, "You can't render a #{renderable}."
 			end

--- a/test/phlex/view/renderable/render.rb
+++ b/test/phlex/view/renderable/render.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-Example = Class.new(Phlex::HTML)
+class Example < Phlex::HTML
+	def template
+		h1 { "Hello" }
+	end
+end
 
 describe Phlex::HTML do
 	extend ViewHelper
@@ -13,9 +17,8 @@ describe Phlex::HTML do
 				end
 			end
 
-			it "raises an ArgumentError" do
-				expect { output }.to raise_exception ArgumentError,
-					message: be == "You tried to render the Phlex view class: #{Example.name} but you probably meant to render an instance of that class instead."
+			it "renders a new instance of that view" do
+				expect(output).to be == "<h1>Hello</h1>"
 			end
 		end
 


### PR DESCRIPTION
When rendering a view, if you're not passing any arguments to the initializer, you don’t need to call `.new`.

After this change, these two are equivalent.

```ruby
render(Heading) { "Hello" }
render(Heading.new) { "Hello" }
```