### PR TITLE
Disable Experimental Warnings configuration option

### DIFF
--- a/lib/phlex/configuration.rb
+++ b/lib/phlex/configuration.rb
@@ -2,6 +2,12 @@
 
 module Phlex
 	class Configuration
-		# Config coming soon.
+		attr_writer :experimental_warnings
+
+		def experimental_warnings
+			return @experimental_warnings if defined? @experimental_warnings
+
+			true
+		end
 	end
 end

--- a/lib/phlex/experimental.rb
+++ b/lib/phlex/experimental.rb
@@ -3,7 +3,10 @@
 module Phlex
 	module Experimental
 		def before_template
-			puts "Warning: #{self.class.name} is experimental and subject to change."
+			if Phlex.configuration.experimental_warnings
+				puts "Warning: #{self.class.name} is experimental and subject to change."
+			end
+
 			super
 		end
 	end


### PR DESCRIPTION
Allow people to disable the experimental feature warnings with a configuration option.

```ruby
Phlex.configure do |c|
  c.experimental_warnings = false
end
```

Closes #404 