### PR TITLE
Support yielding from template

### DIFF
--- a/test/phlex/view/call.rb
+++ b/test/phlex/view/call.rb
@@ -31,4 +31,42 @@ describe Phlex::HTML do
 			expect(example.call(buffer)).to be == "xyz"
 		end
 	end
+
+	with "a view that yields an object" do
+		view do
+			def template
+				yield(1, 2)
+			end
+		end
+
+		let(:output) do
+			example.call do |a, b|
+				a + b
+			end
+		end
+
+		it "yields the object correctly" do
+			expect(output).to be == "3"
+		end
+	end
+
+	with "a view that yields nothing" do
+		view do
+			def template
+				yield
+			end
+
+			def some_method
+				h1 { "Hi" }
+			end
+		end
+
+		let(:output) do
+			example.call(&:some_method)
+		end
+
+		it "yields the view itself" do
+			expect(output).to be == "<h1>Hi</h1>"
+		end
+	end
 end


### PR DESCRIPTION
Add support for explicitly yielding an object from a template. Closes #403 