### PR TITLE
Always set rendered at least once

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -154,7 +154,7 @@ module Phlex
 				end
 			end
 
-			self.class.rendered_at_least_once ||= true
+			self.class.rendered_at_least_once = true
 
 			buffer
 		end


### PR DESCRIPTION
The `||=` here took longer than a simple assignment.