### PR TITLE
Call `render?` after setting view context

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -134,11 +134,11 @@ module Phlex
 		end
 
 		def call(buffer = +"", view_context: nil, parent: nil, &block)
-			return buffer unless render?
-
 			@_target = buffer
 			@_view_context = view_context
 			@_parent = parent
+
+			return buffer unless render?
 
 			around_template do
 				if block_given?

--- a/test/phlex/view/call.rb
+++ b/test/phlex/view/call.rb
@@ -15,20 +15,20 @@ describe Phlex::HTML do
 		end
 	end
 
-	with "`render?` method returning false" do
+	with "`render?` method returning false when the view context is true" do
 		view do
 			def template
 				text "Hi"
 			end
 
 			def render?
-				false
+				!@_view_context
 			end
 		end
 
 		it "returns buffer content" do
 			buffer = "xyz"
-			expect(example.call(buffer)).to be == "xyz"
+			expect(example.call(buffer, view_context: true)).to be == "xyz"
 		end
 	end
 


### PR DESCRIPTION
This will allow you to use the view context form within the `render?` method.