### PR TITLE
Render data hash with string keys, take 2

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -354,7 +354,7 @@ module Phlex
 				when Symbol
 					buffer << " " << name << '="' << ERB::Util.html_escape(v.name) << '"'
 				when Hash
-					_build_attributes(v.transform_keys { "#{k}-#{_1.name.tr('_', '-')}" }, buffer: buffer)
+					_build_attributes(v.transform_keys { "#{k}-#{_1.to_s.tr('_', '-')}" }, buffer: buffer)
 				else
 					buffer << " " << name << '="' << ERB::Util.html_escape(v.to_s) << '"'
 				end

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -354,7 +354,14 @@ module Phlex
 				when Symbol
 					buffer << " " << name << '="' << ERB::Util.html_escape(v.name) << '"'
 				when Hash
-					_build_attributes(v.transform_keys { "#{k}-#{_1.to_s.tr('_', '-')}" }, buffer: buffer)
+					_build_attributes(
+						v.transform_keys { |subkey|
+							case subkey
+								when Symbol then"#{k}-#{subkey.name.tr('_', '-')}"
+								else "#{k}-#{subkey}"
+							end
+						}, buffer: buffer
+					)
 				else
 					buffer << " " << name << '="' << ERB::Util.html_escape(v.to_s) << '"'
 				end

--- a/test/phlex/view/attributes.rb
+++ b/test/phlex/view/attributes.rb
@@ -15,6 +15,18 @@ describe Phlex::HTML do
 		end
 	end
 
+	with "string keyed hash attributes" do
+		view do
+			def template
+				div data: { "name_first_name" => "Joel" }
+			end
+		end
+
+		it "dasherizes the attributes" do
+			expect(output).to be == %(<div data-name-first-name="Joel"></div>)
+		end
+	end
+
 	if RUBY_ENGINE == "ruby"
 		with "unique tag attributes" do
 			view do

--- a/test/phlex/view/attributes.rb
+++ b/test/phlex/view/attributes.rb
@@ -22,8 +22,8 @@ describe Phlex::HTML do
 			end
 		end
 
-		it "dasherizes the attributes" do
-			expect(output).to be == %(<div data-name-first-name="Joel"></div>)
+		it "flattens the attributes without dasherizing them" do
+			expect(output).to be == %(<div data-name_first_name="Joel"></div>)
 		end
 	end
 


### PR DESCRIPTION
Reverts joeldrapper/phlex#419, which reverted #418 which I accidentally merged. I’m copying below the original description from #418, since this PR is a replacement for that:

from @djfpaagman

I was building a component with some Stimulus `data-` attributes and noticed you can't use string keys for the `data` hash, for example:

```ruby
def template
	div data: { "name_first_name" => "Joel" }
end
```

will give:

```
describe Phlex::HTML with string keyed hash attributes it dasherizes the attributes test/phlex/view/attributes.rb:25
        ⚠ NoMethodError: undefined method `name' for "name_first_name":String
                /Users/dennis/Code/phlex/lib/phlex/html.rb:357 block (2 levels) in _build_attributes
```

I'm opening this PR as a starting point. I think using `to_s` has some downsides as it makes a copy of the string/symbol every time so memory wise it's not a great solution. But i'm also not sure if a class check is worth it either, probably most of the times a hash with symbol keys will be used. 

What do you think?