### PR TITLE
Update Gemfile removing `syntax_suggest`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gemspec
 
 gem "rubocop"
 gem "sus"
-gem "syntax_suggest"
 gem "zeitwerk"
 gem "benchmark-ips"
 gem "erb"


### PR DESCRIPTION
It's a default gem now and we don't need to require it.