### PR TITLE
Rename private methods

### DIFF
--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -13,11 +13,11 @@ module Phlex
         def #{element}(**attributes, &block)
           if attributes.length > 0
             if block_given?
-              @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(**attributes)) << ">"
+              @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || __attributes__(**attributes)) << ">"
               yield_content(&block)
               @_target << "</#{tag}>"
             else
-              @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(**attributes)) << "></#{tag}>"
+              @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
             end
           else
             if block_given?
@@ -40,7 +40,7 @@ module Phlex
 
         def #{element}(**attributes)
           if attributes.length > 0
-            @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || _attributes(**attributes)) << ">"
+            @_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || __attributes__(**attributes)) << ">"
           else
             @_target << "<#{tag}>"
           end

--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -15,12 +15,12 @@ module Phlex::Helpers
 
 			if truthy
 				case token
-					when Hash then _append_token(tokens, token[:then])
-					else _append_token(tokens, token)
+					when Hash then __append_token__(tokens, token[:then])
+					else __append_token__(tokens, token)
 				end
 			else
 				case token
-					when Hash then _append_token(tokens, token[:else])
+					when Hash then __append_token__(tokens, token[:else])
 				end
 			end
 		end
@@ -28,7 +28,7 @@ module Phlex::Helpers
 		tokens.join(" ")
 	end
 
-	private def _append_token(tokens, token)
+	private def __append_token__(tokens, token)
 		case token
 			when nil then nil
 			when String then tokens << token

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -319,13 +319,13 @@ module Phlex
 			nil
 		end
 
-		private def _attributes(**attributes)
+		private def __attributes__(**attributes)
 			if attributes[:href]&.start_with?(/\s*javascript/)
 				attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "")
 			end
 
 			buffer = +""
-			_build_attributes(attributes, buffer: buffer)
+			__build_attributes__(attributes, buffer: buffer)
 
 			unless self.class.rendered_at_least_once
 				Phlex::ATTRIBUTE_CACHE[attributes.hash] = buffer.freeze
@@ -334,7 +334,7 @@ module Phlex
 			buffer
 		end
 
-		private def _build_attributes(attributes, buffer:)
+		private def __build_attributes__(attributes, buffer:)
 			attributes.each do |k, v|
 				next unless v
 
@@ -357,7 +357,7 @@ module Phlex
 				when Symbol
 					buffer << " " << name << '="' << ERB::Util.html_escape(v.name) << '"'
 				when Hash
-					_build_attributes(
+					__build_attributes__(
 						v.transform_keys { |subkey|
 							case subkey
 								when Symbol then"#{k}-#{subkey.name.tr('_', '-')}"


### PR DESCRIPTION
Change the naming convention of private methods from a single underscore `_name` to double underscores either side `__name__`. This is to support `_name` methods for elements.