### PR TITLE
Add experimental `DeferredRender` module

### DIFF
--- a/lib/phlex/deferred_render.rb
+++ b/lib/phlex/deferred_render.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Phlex
+	module DeferredRender
+		include Experimental
+
+		def template(&block)
+			capture(&block) # yield the block and throw away the output
+			super() # empty parens ensure we don't pass the block which could be yielded a second time
+		end
+	end
+end


### PR DESCRIPTION
`DeferredRender` yields the content block early, throwing away the results, so you can render your template having already captured everything with your own DSL.