### PR TITLE
Add `Phlex::HTML#render` for rendering a component into a String

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -131,6 +131,11 @@ module Phlex
 
 		class << self
 			attr_accessor :rendered_at_least_once
+
+			def call(...)
+				new(...).call
+			end
+			alias_method :render, :call
 		end
 
 		def call(buffer = +"", view_context: nil, parent: nil, &block)

--- a/test/phlex/view/static_call.rb
+++ b/test/phlex/view/static_call.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Example < Phlex::HTML
+	def template
+		h1 { "Hi" }
+	end
+end
+
+describe Phlex::HTML do
+	with "static #call" do
+		it "renders the view" do
+			expect(Example.call).to be == "<h1>Hi</h1>"
+		end
+	end
+
+	with "static #render" do
+		it "renders the view" do
+			expect(Example.render).to be == "<h1>Hi</h1>"
+		end
+	end
+end


### PR DESCRIPTION
I'm not sure if this was left out on purpose, but I feel like having a static `render` method shorthand for `Phlex::HTML` to render the component into a string reads a lot nicer compared to having to instantiate the class and calling `call` after, especially when working with blocks.

For example, if you are are using Phlex components for Turbo Stream/CableReady payloads:

```ruby
respond_to do |format|
  format.turbo_stream { 
    render turbo_stream: turbo_stream.replace("#posts", Views::Posts::Index.new(posts: Post.all) { ... }.call ) 
  } 
end
```
vs.
```ruby
respond_to do |format|
  format.turbo_stream {
    render turbo_stream: turbo_stream.replace("#posts", Views::Posts::Index.render(posts: Post.all) { ... }) 
  } 
end
```
Let me know if you feel like this is a valuable addition.
