### PR TITLE
Implement `DeferredRender` with new `around_content` hook

### DIFF
--- a/lib/phlex/deferred_render.rb
+++ b/lib/phlex/deferred_render.rb
@@ -2,11 +2,9 @@
 
 module Phlex
 	module DeferredRender
-		include Experimental
-
-		def template(&block)
-			capture(&block) # yield the block and throw away the output
-			super() # empty parens ensure we don't pass the block which could be yielded a second time
+		def around_content(&block)
+			capture(&block)
+			super() # empty parens stop passing the block
 		end
 	end
 end

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -143,10 +143,12 @@ module Phlex
 			around_template do
 				if block_given?
 					template do |*args|
-						if args.length > 0
-							yield_content_with_args(*args, &block)
-						else
-							yield_content(&block)
+						around_content do
+							if args.length > 0
+								yield_content_with_args(*args, &block)
+							else
+								yield_content(&block)
+							end
 						end
 					end
 				else
@@ -259,6 +261,10 @@ module Phlex
 			before_template
 			yield
 			after_template
+		end
+
+		private def around_content
+			yield
 		end
 
 		private def before_template


### PR DESCRIPTION
`DeferredRender` was previously implemented using a prepended Module, which leads to problems when you subclass a deferred-render-view. If the subclass defines a `template` method, the `DeferredRender` override is overridden.

To solve this, I’ve instead implemented an `around_content` hook that `DeferredRender` now defines to stop the content block from being executed. There's a very slight performance cost, but I think it's worth it to have this hook.