### PR TITLE
Guard for href as non-string

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -320,7 +320,7 @@ module Phlex
 		end
 
 		private def __attributes__(**attributes)
-			if attributes[:href]&.start_with?(/\s*javascript/)
+			if attributes[:href].is_a?(String) && attributes[:href].start_with?(/\s*javascript/)
 				attributes[:href] = attributes[:href].sub(/^\s*(javascript:)+/, "")
 			end
 


### PR DESCRIPTION
The check for JS in `href` attribute fails if `href` is not a string. This PR simply guards against that.