### PR TITLE
Improve `DeferredRender`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,8 @@ Layout/CaseIndentation:
 Style/StringConcatenation:
   Enabled: false
 
-
+Style/CaseEquality:
+  Enabled: false
 
 Security/Eval:
   Enabled: false

--- a/lib/phlex/black_hole.rb
+++ b/lib/phlex/black_hole.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Phlex
+	module BlackHole
+		extend self
+
+		def <<(anything)
+			self
+		end
+
+		def length
+			0
+		end
+	end
+end

--- a/lib/phlex/deferred_render.rb
+++ b/lib/phlex/deferred_render.rb
@@ -3,10 +3,5 @@
 module Phlex
 	module DeferredRender
 		include Experimental
-
-		def template(&block)
-			capture(&block) # yield the block and throw away the output
-			super() # empty parens ensure we don't pass the block which could be yielded a second time
-		end
 	end
 end


### PR DESCRIPTION
With this change `DeferredRender` will always defer rendering, even when a component is subclassed and its `template` method is overridden. `DeferredRender` should now be included rather than prepended.