### PR TITLE
Don't capture blocks when yielding

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -233,13 +233,13 @@ module Phlex
 			nil
 		end
 
-		def unsafe_raw(content = nil, &block)
+		def unsafe_raw(content = nil)
 			return nil unless content
 
 			@_target << content
 		end
 
-		def capture(&block)
+		def capture
 			return unless block_given?
 
 			original_buffer = @_target
@@ -292,7 +292,7 @@ module Phlex
 			nil
 		end
 
-		private def yield_content(&block)
+		private def yield_content
 			return unless block_given?
 
 			original_length = @_target.length
@@ -317,7 +317,7 @@ module Phlex
 			nil
 		end
 
-		private def yield_content_with_args(*args, &block)
+		private def yield_content_with_args(*args)
 			return unless block_given?
 
 			original_length = @_target.length

--- a/test/phlex/view/content.rb
+++ b/test/phlex/view/content.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	with "content" do
 		view do
-			def template(&block)
+			def template
 				h1 { "Before" }
 				yield
 				h2 { "After" }


### PR DESCRIPTION
When yielding, we don't need to capture the given block to an instance variable. This results in an overall ~4% performance improvement.

Before
```
ruby 3.2.0 (2022-12-25 revision a528908271) [arm64-darwin22]
Warming up --------------------------------------
                Page     8.976k i/100ms
Calculating -------------------------------------
                Page     89.467k (± 0.4%) i/s -    448.800k in   5.016480s
```

After
```
ruby 3.2.0 (2022-12-25 revision a528908271) [arm64-darwin22]
Warming up --------------------------------------
                Page     9.324k i/100ms
Calculating -------------------------------------
                Page     93.024k (± 0.4%) i/s -    466.200k in   5.011671s
```