### PR TITLE
Detect block passed to `new`

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -137,9 +137,11 @@ module Phlex
 			end
 			alias_method :render, :call
 
-			def new
-				if block_given?
-					raise ArgumentError, "You passed a block to #{name}.new. You probably meant to pass it to #{name}#call."
+			def new(*args, &block)
+				if block
+					object = super(*args, &nil)
+					object.instance_variable_set(:@_content_block, block)
+					object
 				else
 					super
 				end
@@ -151,10 +153,12 @@ module Phlex
 			@_view_context = view_context
 			@_parent = parent
 
+			block ||= @_content_block
+
 			return buffer unless render?
 
 			around_template do
-				if block_given?
+				if block
 					if DeferredRender === self
 						__vanish__(&block)
 						template

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -136,6 +136,14 @@ module Phlex
 				new(...).call
 			end
 			alias_method :render, :call
+
+			def new
+				if block_given?
+					raise ArgumentError, "You passed a block to #{name}.new. You probably meant to pass it to #{name}#call."
+				else
+					super
+				end
+			end
 		end
 
 		def call(buffer = +"", view_context: nil, parent: nil, &block)

--- a/test/phlex/view/new.rb
+++ b/test/phlex/view/new.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Example < Phlex::HTML
+	def template(&block)
+		h1(&block)
+	end
+end
+
+describe Phlex::HTML do
+	extend ViewHelper
+
+	with "a block passed to new" do
+		view do
+			def template
+				render Example.new { "Hello" }
+			end
+		end
+
+		it "treats the block as content" do
+			expect(output).to be == "<h1>Hello</h1>"
+		end
+	end
+end


### PR DESCRIPTION
It’s easy to accidentally pass a block to the class method `new` instead of the instance method `render`. For example, if you forget the parentheses around a brace block when rendering a view inside another view.

```ruby
# Block sent to `render`
render(Example.new) { "Hello" }

# Block sent to `new`
render Example.new { "Hello" }
```

We can handle this gracefully and save the block for later by overriding `.new`.

There's a performance cost to this, but I think it's worth it.

Before
```
ruby 3.2.0 (2022-12-25 revision a528908271) [arm64-darwin22]
Warming up --------------------------------------
                Page     9.314k i/100ms
Calculating -------------------------------------
                Page     93.119k (± 0.7%) i/s -    465.700k in   5.001396s
```

After
```
ruby 3.2.0 (2022-12-25 revision a528908271) [arm64-darwin22]
Warming up --------------------------------------
                Page     9.194k i/100ms
Calculating -------------------------------------
                Page     91.961k (± 0.2%) i/s -    468.894k in   5.098888s
```