### PR TITLE
Add `clearwater` project to "Prior Art" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ Thanks [Logology](https://www.logology.co) for sponsoring our logo.
 - [tubby](https://github.com/judofyr/tubby)
 - [hoshi](https://github.com/pete/hoshi)
 - [hyperstack](https://github.com/hyperstack-org/hyperstack)
+- [clearwater](https://github.com/clearwater-rb/clearwater)


### PR DESCRIPTION
I just stumbled across the [`clearwater`](https://github.com/clearwater-rb) project and thought it might make sense to also add it to the "Prior Art" list in the README 