### PR TITLE
Fix using keyword arguments in initializer

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -137,9 +137,9 @@ module Phlex
 			end
 			alias_method :render, :call
 
-			def new(*args, &block)
+			def new(*args, **kwargs, &block)
 				if block
-					object = super(*args, &nil)
+					object = super(*args, **kwargs, &nil)
 					object.instance_variable_set(:@_content_block, block)
 					object
 				else

--- a/test/phlex/view/new.rb
+++ b/test/phlex/view/new.rb
@@ -6,6 +6,24 @@ class Example < Phlex::HTML
 	end
 end
 
+class ExampleWithArgs < Phlex::HTML
+	def initialize(name, should_render: false)
+		@name = name
+		@should_render = should_render
+	end
+
+	def render?
+		@should_render
+	end
+
+	def template
+		h1 {
+			yield
+			text(", #{@name}")
+		}
+	end
+end
+
 describe Phlex::HTML do
 	extend ViewHelper
 
@@ -18,6 +36,18 @@ describe Phlex::HTML do
 
 		it "treats the block as content" do
 			expect(output).to be == "<h1>Hello</h1>"
+		end
+	end
+
+	with "a block and arguments passed to new" do
+		view do
+			def template
+				render ExampleWithArgs.new("World", should_render: true) { "Hello" }
+			end
+		end
+
+		it "treats the block as content, and passes the args on" do
+			expect(output).to be == "<h1>Hello, World</h1>"
 		end
 	end
 end


### PR DESCRIPTION
The override of `new` added in #438 did not support keyword arguments, and would cause an ArgumentError when called with them.