### PR TITLE
Unbuffered decorator

### DIFF
--- a/lib/phlex/unbuffered.rb
+++ b/lib/phlex/unbuffered.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Phlex
+	class Unbuffered < BasicObject
+		CACHE = {}
+
+		def self.call(object)
+			decorator = CACHE[object.class.name] ||= ::Class.new(self)
+			decorator.new(object)
+		end
+
+		def initialize(object)
+			@object = object
+		end
+
+		def inspect
+			"Unbuffered(#{@object.class.name})[object: #{@object.inspect}]"
+		end
+
+		# Borrow some important methods from Object
+		define_method :__class__,
+			::Object.instance_method(:class)
+
+		define_method :__public_send__,
+			::Object.instance_method(:public_send)
+
+		define_method :__callee__,
+			::Object.instance_method(:__callee__)
+
+		def respond_to_missing?(...)
+			@object.respond_to?(...)
+		end
+
+		def method_missing(name, *args, &block)
+			if @object.respond_to?(name)
+				# If the object responds to this method, we want to define it by aliasing the __output_method__.
+				__class__.alias_method(name, :__output_method__)
+
+				# Now we've defined this missing method, we can call it.
+				__public_send__(name, *args, &block)
+			else
+				super
+			end
+		end
+
+		# This method is designed to be aliased and references the callee which is whatever alias you called.
+		def __output_method__(*args, &block)
+			@object.capture { @object.public_send(__callee__, *args, &block) }
+		end
+
+		def __forward_method__(*args, &block)
+			@object.public_send(__callee__, *args, &block)
+		end
+
+		# Forward some methods to the original underlying method
+		alias_method :call, :__forward_method__
+		alias_method :send, :__forward_method__
+		alias_method :public_send, :__forward_method__
+	end
+end

--- a/test/phlex/unbuffered.rb
+++ b/test/phlex/unbuffered.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class Example < Phlex::HTML
+	def template
+		yield
+	end
+
+	def foo
+		h1 { "Foo" }
+	end
+
+	def bar
+		"bar"
+	end
+end
+
+describe Phlex::Unbuffered do
+	it "caches a decorator class for each class of view" do
+		a = Phlex::Unbuffered.call(Example.new).__class__
+		b = Phlex::Unbuffered.call(Example.new).__class__
+
+		expect(a).to be == b
+	end
+
+	it "captures the underlying view output methods" do
+		captured_output = nil
+
+		output = Example.call do |v|
+			unbuffered_view = Phlex::Unbuffered.call(v)
+			captured_output = unbuffered_view.foo
+			nil
+		end
+
+		expect(captured_output).to be == "<h1>Foo</h1>"
+		expect(output).to be == ""
+	end
+
+	it "delegates #send" do
+		view = Example.new
+		unbuffered_view = Phlex::Unbuffered.call(view)
+		expect(view).to receive(:send).with(:bar)
+
+		unbuffered_view.send(:bar)
+	end
+end


### PR DESCRIPTION
A decorator for Phlex views that wraps each method call in a `capture` block, so it doesn't affect the main target buffer.