### PR TITLE
Warn when redefining underscored methods

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -408,5 +408,14 @@ module Phlex
 
 			buffer
 		end
+
+		# This should be the last method defined
+		def self.method_added(method_name)
+			if method_name[0] == "_" && Phlex::HTML.instance_methods.include?(method_name) && instance_method(method_name).owner != Phlex::HTML
+				raise NameError, "👋 Redefining the method `#{name}##{method_name}` is not a good idea."
+			end
+
+			super
+		end
 	end
 end

--- a/test/phlex/method_added.rb
+++ b/test/phlex/method_added.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Example < Phlex::HTML
+end
+
+describe Phlex::HTML do
+	it "raises if you try to redefine an underscored method" do
+		expect { Example.define_method(:_h1) { nil } }.to raise_exception(Phlex::NameError)
+	end
+
+	it "doesn't raise if you define a new underscored method" do
+		Example.define_method(:_some_random_method) { nil }
+	end
+end


### PR DESCRIPTION
Strongly discourage overriding `Phlex::HTML` methods that start with an underscore `_`.

Closes #440