### PR TITLE
No false positives for `javascript:` link detection

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -369,11 +369,11 @@ module Phlex
 		end
 
 		private def __final_attributes__(**attributes)
-			if attributes[:href]&.start_with?(/\s*javascript/)
+			if attributes[:href]&.start_with?(/\s*javascript:/)
 				attributes.delete(:href)
 			end
 
-			if attributes["href"]&.start_with?(/\s*javascript/)
+			if attributes["href"]&.start_with?(/\s*javascript:/)
 				attributes.delete("href")
 			end
 


### PR DESCRIPTION
Phlex would not allow you to link to a resource called `javascript`. Now it does, while still blocking naughty `javascript:` links.