### PR TITLE
Make `DeferredRender` not experimental

### DIFF
--- a/lib/phlex/deferred_render.rb
+++ b/lib/phlex/deferred_render.rb
@@ -2,6 +2,6 @@
 
 module Phlex
 	module DeferredRender
-		include Experimental
+		# This module doesn't do anything. Phlex::HTML#call checks for its inclusion in the ancestry instead.
 	end
 end


### PR DESCRIPTION
I’ve been using `DeferredRender` in an app for a while now, and I’m very happy with it. I think we can conclude the experiment now.