### PR TITLE
Cache unbuffered class on the view class

### DIFF
--- a/lib/phlex/unbuffered.rb
+++ b/lib/phlex/unbuffered.rb
@@ -2,13 +2,6 @@
 
 module Phlex
 	class Unbuffered < BasicObject
-		CACHE = ::Concurrent::Map.new
-
-		def self.call(object)
-			decorator = CACHE.compute_if_absent(object.class.name) { ::Class.new(self) }
-			decorator.new(object)
-		end
-
 		def initialize(object)
 			@object = object
 		end
@@ -23,9 +16,6 @@ module Phlex
 
 		define_method :__public_send__,
 			::Object.instance_method(:public_send)
-
-		define_method :__callee__,
-			::Object.instance_method(:__callee__)
 
 		def respond_to_missing?(...)
 			@object.respond_to?(...)

--- a/test/phlex/unbuffered.rb
+++ b/test/phlex/unbuffered.rb
@@ -16,18 +16,14 @@ end
 
 describe Phlex::Unbuffered do
 	it "caches a decorator class for each class of view" do
-		a = Phlex::Unbuffered.call(Example.new).__class__
-		b = Phlex::Unbuffered.call(Example.new).__class__
-
-		expect(a).to be == b
+		expect(Example.__unbuffered_class__).to be == Example.__unbuffered_class__
 	end
 
 	it "captures the underlying view output methods" do
 		captured_output = nil
 
-		output = Example.call do |v|
-			unbuffered_view = Phlex::Unbuffered.call(v)
-			captured_output = unbuffered_view.foo
+		output = Example.call do |view|
+			captured_output = view.unbuffered.foo
 			nil
 		end
 
@@ -37,9 +33,8 @@ describe Phlex::Unbuffered do
 
 	it "delegates #send" do
 		view = Example.new
-		unbuffered_view = Phlex::Unbuffered.call(view)
 		expect(view).to receive(:send).with(:bar)
 
-		unbuffered_view.send(:bar)
+		view.unbuffered.send(:bar)
 	end
 end


### PR DESCRIPTION
Instead of maintaining a separate cache of unbuffered classes, the view classes themselves have a cached unbuffered class. 