### PR TITLE
Add `<hgroup>` tag to the list of HTML elements

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -49,6 +49,7 @@ module Phlex
 			h6: "h6",
 			head: "head",
 			header: "header",
+			hgroup: "hgroup",
 			html: "html",
 			i: "i",
 			iframe: "iframe",


### PR DESCRIPTION
The `<hgroup>` tag is back in business in the latest HTML spec for wrapping an h* tag and a p tag for a title/subtitle grouping. Makes sense to support it here.