### PR TITLE
Benchmarks haml hamlit slim

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,17 @@ gemspec
 gem "rubocop"
 gem "sus"
 gem "zeitwerk"
-gem "benchmark-ips"
 gem "erb"
 
 group :test do
 	gem "i18n"
 	gem "memory_profiler"
+end
+
+
+group :development do
+	gem "benchmark-ips"
+	gem "haml", "~> 6"	
+	gem "slim", "~> 5"
+	gem "hamlit", "~> 3"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,9 @@ group :test do
 	gem "memory_profiler"
 end
 
-
 group :development do
 	gem "benchmark-ips"
-	gem "haml", "~> 6"	
+	gem "haml", "~> 6"
 	gem "slim", "~> 5"
 	gem "hamlit", "~> 3"
 end

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Phlex lets you compose web views in pure Ruby. It’s super-fast, thread-safe an
 
 Documentation can be found at [www.phlex.fun](https://www.phlex.fun).
 
+### Testing
+
+We use [`sus`](https://github.com/ioquatix/sus) execute tests. To run gem's testsuite use the following command
+
+```
+bundle exec sus
+```
+
 ### Support ✋
 
 If you run into any trouble, please [start a discussion](https://github.com/joeldrapper/phlex/discussions/new), or [open an issue](https://github.com/joeldrapper/phlex/issues/new) if you think you’ve found a bug.

--- a/bench.rb
+++ b/bench.rb
@@ -10,7 +10,6 @@ require "benchmark/ips"
 require_relative "fixtures/page"
 require_relative "fixtures/layout"
 
-
 # Sample Data
 Product = Struct.new(:name, :price, :color)
 @products = [
@@ -18,7 +17,7 @@ Product = Struct.new(:name, :price, :color)
 	Product.new("Product 2", 20, "green"),
 	Product.new("Product 3", 30, "blue"),
 	Product.new("Product 4", 40, "yellow"),
-	Product.new("Product 5", 50, "orange"),
+	Product.new("Product 5", 50, "orange")
 ]
 
 # Templates
@@ -31,7 +30,6 @@ Product = Struct.new(:name, :price, :color)
 
 @slim_layout = Slim::Template.new("fixtures/slim/layout.slim")
 @slim_page = Slim::Template.new("fixtures/slim/page.slim")
-
 
 @phlex_page = Example::Page.new(products: @products)
 

--- a/bench.rb
+++ b/bench.rb
@@ -41,7 +41,6 @@ def html_from_hamlit
 	end
 end
 
-
 def html_from_phlex
 	@phlex_page.call
 end
@@ -54,11 +53,10 @@ end
 check_html_is_same(html_from_phlex, html_from_phlex)
 
 # HAML & Phlex produce the same HTML but HAML is using ' and Phlex is using ", also HAML is using \n, and Phlex producing a really long line :)
-# The only other difference is order of attributes, but that's not important 
+# The only other difference is order of attributes, but that's not important
 # HAML: <meta content='width=device-width,initial-scale=1' name='viewport'>
 # Phlex: <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">
 # check_html_is_same(html_from_phlex, html_from_haml(@haml_layout, @haml_page).gsub("\n", "").gsub("'","\""))
-
 
 Benchmark.ips do |x|
 	puts RUBY_DESCRIPTION
@@ -69,5 +67,3 @@ Benchmark.ips do |x|
 	x.report("Slim Page") { html_from_slim }
 	x.compare!
 end
-
-

--- a/bench.rb
+++ b/bench.rb
@@ -10,7 +10,18 @@ require "benchmark/ips"
 require_relative "fixtures/page"
 require_relative "fixtures/layout"
 
-# Let's preload HAML templates from disk
+
+# Sample Data
+Product = Struct.new(:name, :price, :color)
+@products = [
+	Product.new("Product 1", 10, "red"),
+	Product.new("Product 2", 20, "green"),
+	Product.new("Product 3", 30, "blue"),
+	Product.new("Product 4", 40, "yellow"),
+	Product.new("Product 5", 50, "orange"),
+]
+
+# Templates
 
 @haml_layout = Haml::Template.new("fixtures/haml/layout.haml", escape_html: false)
 @haml_page = Haml::Template.new("fixtures/haml/page.haml", escape_html: false)
@@ -21,23 +32,25 @@ require_relative "fixtures/layout"
 @slim_layout = Slim::Template.new("fixtures/slim/layout.slim")
 @slim_page = Slim::Template.new("fixtures/slim/page.slim")
 
-@phlex_page = Example::Page.new
 
+@phlex_page = Example::Page.new(products: @products)
+
+# Helper methods
 def html_from_slim
 	@slim_layout.render do
-		@slim_page.render
+		@slim_page.render(Object.new, products: @products)
 	end
 end
 
 def html_from_haml
 	@haml_layout.render do
-		@haml_page.render
+		@haml_page.render(Object.new, products: @products)
 	end
 end
 
 def html_from_hamlit
 	@hamlit_layout.render do
-		@hamlit_page.render
+		@haml_page.render(Object.new, products: @products)
 	end
 end
 

--- a/bench.rb
+++ b/bench.rb
@@ -2,20 +2,72 @@
 # frozen_string_literal: true
 
 require "phlex"
+require "haml"
+require "hamlit"
+require "slim"
 require "benchmark/ips"
 
 require_relative "fixtures/page"
 require_relative "fixtures/layout"
 
-puts RUBY_DESCRIPTION
+# Let's preload HAML templates from disk
 
-a = Example::Page.new.call
-# Example::Page.compile
-# Example::LayoutComponent.compile
-b = Example::Page.new.call
+@haml_layout = Haml::Template.new("fixtures/haml/layout.haml", escape_html: false)
+@haml_page = Haml::Template.new("fixtures/haml/page.haml", escape_html: false)
 
-raise unless a == b
+@hamlit_layout = Hamlit::Template.new("fixtures/haml/layout.haml", escape_html: false)
+@hamlit_page = Hamlit::Template.new("fixtures/haml/page.haml", escape_html: false)
+
+@slim_layout = Slim::Template.new("fixtures/slim/layout.slim")
+@slim_page = Slim::Template.new("fixtures/slim/page.slim")
+
+@phlex_page = Example::Page.new
+
+def html_from_slim
+	@slim_layout.render do
+		@slim_page.render
+	end
+end
+
+def html_from_haml
+	@haml_layout.render do
+		@haml_page.render
+	end
+end
+
+def html_from_hamlit
+	@hamlit_layout.render do
+		@hamlit_page.render
+	end
+end
+
+
+def html_from_phlex
+	@phlex_page.call
+end
+
+def check_html_is_same(a, b)
+	raise "HTML is not the same" unless a == b
+end
+
+# Not sure why we need to compare, but moved this to a separate method?
+check_html_is_same(html_from_phlex, html_from_phlex)
+
+# HAML & Phlex produce the same HTML but HAML is using ' and Phlex is using ", also HAML is using \n, and Phlex producing a really long line :)
+# The only other difference is order of attributes, but that's not important 
+# HAML: <meta content='width=device-width,initial-scale=1' name='viewport'>
+# Phlex: <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">
+# check_html_is_same(html_from_phlex, html_from_haml(@haml_layout, @haml_page).gsub("\n", "").gsub("'","\""))
+
 
 Benchmark.ips do |x|
-	x.report("Page") { Example::Page.new.call }
+	puts RUBY_DESCRIPTION
+	x.config(time: 5, warmup: 2)
+	x.report("Phlex Page") { html_from_phlex }
+	x.report("HAML Page") { html_from_haml }
+	x.report("Hamlit Page") { html_from_hamlit }
+	x.report("Slim Page") { html_from_slim }
+	x.compare!
 end
+
+

--- a/benchmarks/phlex.rb
+++ b/benchmarks/phlex.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This is the orignal benchmark from the Phlex repo
+# It's used to measure the performance of Phlex itself against older versions of itself,
+# to measure improvments over time.
+
+require "phlex"
+require "benchmark/ips"
+
+require_relative "../fixtures/page"
+require_relative "../fixtures/layout"
+
+puts RUBY_DESCRIPTION
+
+a = Example::Page.new.call
+# Example::Page.compile
+# Example::LayoutComponent.compile
+b = Example::Page.new.call
+
+raise unless a == b
+
+Benchmark.ips do |x|
+	x.report("Page") { Example::Page.new.call }
+end

--- a/benchmarks/templates.rb
+++ b/benchmarks/templates.rb
@@ -7,8 +7,8 @@ require "hamlit"
 require "slim"
 require "benchmark/ips"
 
-require_relative "fixtures/page"
-require_relative "fixtures/layout"
+require_relative "../fixtures/page"
+require_relative "../fixtures/layout"
 
 # Sample Data
 Product = Struct.new(:name, :price, :color)
@@ -21,15 +21,15 @@ Product = Struct.new(:name, :price, :color)
 ]
 
 # Templates
+@fixtures_path = File.expand_path("../fixtures", __dir__)
+@haml_layout = Haml::Template.new(File.join(@fixtures_path, "haml", "layout.haml"), escape_html: false)
+@haml_page = Haml::Template.new(File.join(@fixtures_path, "haml", "page.haml"), escape_html: false)
 
-@haml_layout = Haml::Template.new("fixtures/haml/layout.haml", escape_html: false)
-@haml_page = Haml::Template.new("fixtures/haml/page.haml", escape_html: false)
+@hamlit_layout = Hamlit::Template.new(File.join(@fixtures_path, "haml", "layout.haml"), escape_html: false)
+@hamlit_page = Hamlit::Template.new(File.join(@fixtures_path, "haml", "page.haml"), escape_html: false)
 
-@hamlit_layout = Hamlit::Template.new("fixtures/haml/layout.haml", escape_html: false)
-@hamlit_page = Hamlit::Template.new("fixtures/haml/page.haml", escape_html: false)
-
-@slim_layout = Slim::Template.new("fixtures/slim/layout.slim")
-@slim_page = Slim::Template.new("fixtures/slim/page.slim")
+@slim_layout = Slim::Template.new(File.join(@fixtures_path, "slim", "layout.slim"))
+@slim_page = Slim::Template.new(File.join(@fixtures_path, "slim", "page.slim"))
 
 @phlex_page = Example::Page.new(products: @products)
 

--- a/fixtures/haml/layout.haml
+++ b/fixtures/haml/layout.haml
@@ -1,0 +1,16 @@
+%html
+  %head
+    %title Example
+    %meta{:content => "width=device-width,initial-scale=1", :name => "viewport"}/
+    %link{:href => "/assets/tailwind.css", :rel => "stylesheet"}/
+  %body.bg-zinc-100
+    %nav#main_nav.p-5
+      %ul
+        %li.p-5
+          %a{:href => "/"} Home
+        %li.p-5
+          %a{:href => "/about"} About
+        %li.p-5
+          %a{:href => "/contact"} Contact
+    .container.mx-auto.p-5
+      = yield

--- a/fixtures/haml/page.haml
+++ b/fixtures/haml/page.haml
@@ -1,0 +1,13 @@
+%h1 Hi
+%table#test.a.b.c.d.e.f.g
+  %tr
+    %td#test.a.b.c.d.e.f.g
+      %span Hi
+    %td#test.a.b.c.d.e.f.g
+      %span Hi
+    %td#test.a.b.c.d.e.f.g
+      %span Hi
+    %td#test.a.b.c.d.e.f.g
+      %span Hi
+    %td#test.a.b.c.d.e.f.g
+      %span Hi

--- a/fixtures/haml/page.haml
+++ b/fixtures/haml/page.haml
@@ -1,13 +1,8 @@
 %h1 Hi
 %table#test.a.b.c.d.e.f.g
-  %tr
-    %td#test.a.b.c.d.e.f.g
-      %span Hi
-    %td#test.a.b.c.d.e.f.g
-      %span Hi
-    %td#test.a.b.c.d.e.f.g
-      %span Hi
-    %td#test.a.b.c.d.e.f.g
-      %span Hi
-    %td#test.a.b.c.d.e.f.g
-      %span Hi
+  - products.each_with_index do |product, index|
+    %tr{id: index}
+      %td.a.b.c.d.e.f.g{id: [index, 'name'].join('-')}= product.name
+      %td.a.b.c.d.e.f.g{id: [index, 'price'].join('-')}= product.price
+      %td.a.b.c.d.e.f.g{id: [index, 'color'].join('-'), style: "background-color: #{product.color};"}= product.color
+  

--- a/fixtures/page.rb
+++ b/fixtures/page.rb
@@ -5,6 +5,7 @@ module Example
 		def initialize(products: [])
 			@products = products
 		end
+
 		def template
 			render LayoutComponent.new do
 				h1 { "Hi" }
@@ -12,13 +13,13 @@ module Example
 				table id: "test", class: "a b c d e f g" do
 					@products.each_with_index do |product, index|
 						tr id: index do
-							td id: [index, 'name'].join('-'), class: "a b c d e f g" do
+							td id: [index, "name"].join("-"), class: "a b c d e f g" do
 								product.name
 							end
-							td id: [index, 'price'].join('-'), class: "a b c d e f g" do
+							td id: [index, "price"].join("-"), class: "a b c d e f g" do
 								product.price
 							end
-							td id: [index, 'color'].join('-') , class: "a b c d e f g", style: "background-color: #{product.color};" do
+							td id: [index, "color"].join("-"), class: "a b c d e f g", style: "background-color: #{product.color};" do
 								product.color
 							end
 						end

--- a/fixtures/page.rb
+++ b/fixtures/page.rb
@@ -2,30 +2,25 @@
 
 module Example
 	class Page < Phlex::HTML
+		def initialize(products: [])
+			@products = products
+		end
 		def template
 			render LayoutComponent.new do
 				h1 { "Hi" }
 
 				table id: "test", class: "a b c d e f g" do
-					tr do
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
-						end
-
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
-						end
-
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
-						end
-
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
-						end
-
-						td id: "test", class: "a b c d e f g" do
-							span { "Hi" }
+					@products.each_with_index do |product, index|
+						tr id: index do
+							td id: [index, 'name'].join('-'), class: "a b c d e f g" do
+								product.name
+							end
+							td id: [index, 'price'].join('-'), class: "a b c d e f g" do
+								product.price
+							end
+							td id: [index, 'color'].join('-') , class: "a b c d e f g", style: "background-color: #{product.color};" do
+								product.color
+							end
 						end
 					end
 				end

--- a/fixtures/slim/layout.slim
+++ b/fixtures/slim/layout.slim
@@ -1,0 +1,20 @@
+html
+  head
+    title
+      | Example
+    meta[content="width=device-width,initial-scale=1" name="viewport"]
+    link[href="/assets/tailwind.css" rel="stylesheet"]
+  body.bg-zinc-100
+    nav#main_nav.p-5
+      ul
+        li.p-5
+          a[href="/"]
+            | Home
+        li.p-5
+          a[href="/about"]
+            | About
+        li.p-5
+          a[href="/contact"]
+            | Contact
+    .container.mx-auto.p-5
+      == yield

--- a/fixtures/slim/layout.slim
+++ b/fixtures/slim/layout.slim
@@ -1,20 +1,16 @@
 html
   head
-    title
-      | Example
-    meta[content="width=device-width,initial-scale=1" name="viewport"]
-    link[href="/assets/tailwind.css" rel="stylesheet"]
+    title Example
+    meta content="width=device-width,initial-scale=1" name="viewport" /
+    link href="/assets/tailwind.css" rel="stylesheet" /
   body.bg-zinc-100
     nav#main_nav.p-5
       ul
         li.p-5
-          a[href="/"]
-            | Home
+          a href="/"  Home
         li.p-5
-          a[href="/about"]
-            | About
+          a href="/about"  About
         li.p-5
-          a[href="/contact"]
-            | Contact
+          a href="/contact"  Contact
     .container.mx-auto.p-5
       == yield

--- a/fixtures/slim/page.slim
+++ b/fixtures/slim/page.slim
@@ -1,19 +1,11 @@
-h1
-  | Hi
+h1 Hi
 table#test.a.b.c.d.e.f.g
-  tr
-    td#test.a.b.c.d.e.f.g
-      span
-        | Hi
-    td#test.a.b.c.d.e.f.g
-      span
-        | Hi
-    td#test.a.b.c.d.e.f.g
-      span
-        | Hi
-    td#test.a.b.c.d.e.f.g
-      span
-        | Hi
-    td#test.a.b.c.d.e.f.g
-      span
-        | Hi
+  - products.each_with_index do |product, index|
+    tr id=index
+      td.a.b.c.d.e.f.g id="#{[index, 'name'].join('-')}" 
+        = product.name
+      td.a.b.c.d.e.f.g id="#{[index, 'price'].join('-')}"  
+        = product.price
+      td.a.b.c.d.e.f.g id="#{[index, 'color'].join('-')}" style="background-color: #{product.color};" 
+        = product.color
+  

--- a/fixtures/slim/page.slim
+++ b/fixtures/slim/page.slim
@@ -1,0 +1,19 @@
+h1
+  | Hi
+table#test.a.b.c.d.e.f.g
+  tr
+    td#test.a.b.c.d.e.f.g
+      span
+        | Hi
+    td#test.a.b.c.d.e.f.g
+      span
+        | Hi
+    td#test.a.b.c.d.e.f.g
+      span
+        | Hi
+    td#test.a.b.c.d.e.f.g
+      span
+        | Hi
+    td#test.a.b.c.d.e.f.g
+      span
+        | Hi


### PR DESCRIPTION
Hi @joeldrapper 

We briefly touched on benchmarks in this discussion https://github.com/joeldrapper/phlex/discussions/443 

This is a first stab at benchmarks, just based of what you already had.  Obviously Phlex code is not compiled, as you said before in the discussion and on Remote Ruby podcast that I just listened to, it still needs work.  My expectations, is that once  it passes through compiler, it should be on par with others. 

To my surprise Slim was faster, than Haml & Hamlt , but I'm guessing that's because the test is trivial.  I'm quite possibly doing something wrong as well 😸 


Hopefully this is a start in the right direction. 


My results running on ruby 3.2  `ruby --jit bench.rb`


```shell
ruby 3.2.0 (2022-12-25 revision a528908271) +YJIT [x86_64-darwin22]
Warming up --------------------------------------
          Phlex Page     5.873k i/100ms
           HAML Page    12.048k i/100ms
         Hamlit Page    11.044k i/100ms
           Slim Page    19.863k i/100ms
Calculating -------------------------------------
          Phlex Page     62.061k (± 4.4%) i/s -    311.269k in   5.025985s
           HAML Page    138.166k (± 4.3%) i/s -    698.784k in   5.067378s
         Hamlit Page    138.280k (± 4.9%) i/s -    695.772k in   5.045130s
           Slim Page    197.794k (± 3.2%) i/s -    993.150k in   5.026305s

Comparison:
           Slim Page:   197794.2 i/s
         Hamlit Page:   138279.8 i/s - 1.43x  (± 0.00) slower
           HAML Page:   138165.6 i/s - 1.43x  (± 0.00) slower
          Phlex Page:    62061.1 i/s - 3.19x  (± 0.00) slower

```

