### PR TITLE
Omit false, nil and empty strings when joining tokens

### DIFF
--- a/lib/phlex/helpers.rb
+++ b/lib/phlex/helpers.rb
@@ -25,7 +25,7 @@ module Phlex::Helpers
 			end
 		end
 
-		tokens.join(" ")
+		tokens.select(&:itself).map(&:to_s).reject(&:empty?).join(" ")
 	end
 
 	private def __append_token__(tokens, token)


### PR DESCRIPTION
This change omits false, nil and empty strings when using 'tokens(...)'. The default case probably is that you don't normally want these in a class attribute. It also simplifies use cases where you have conditional tokens, e.g.

```Ruby
tokens("nav-link", selected && "selected")
```

Or if you have optional class names in a component

```Ruby
tokens("button", button_type) # button_type may either be nil or a custom type supplied to the component
```
