### PR TITLE
Add SVG tag tests

### DIFF
--- a/fixtures/view_helper.rb
+++ b/fixtures/view_helper.rb
@@ -13,4 +13,10 @@ module ViewHelper
 			Class.new(Phlex::HTML, &block)
 		end
 	end
+
+	def svg_view(&block)
+		let :view do
+			Class.new(Phlex::SVG, &block)
+		end
+	end
 end

--- a/lib/phlex/testing/view_helper.rb
+++ b/lib/phlex/testing/view_helper.rb
@@ -3,7 +3,7 @@
 module Phlex::Testing
 	module ViewHelper
 		def render(view, &block)
-			if view.is_a?(Class) && view < Phlex::HTML
+			if view.is_a?(Class) && view < Phlex::SGML
 				view = view.new
 			end
 

--- a/test/phlex/testing/view_helper.rb
+++ b/test/phlex/testing/view_helper.rb
@@ -2,9 +2,17 @@
 
 require "phlex/testing/view_helper"
 
-class Example < Phlex::HTML
+class ExampleHTML < Phlex::HTML
 	def template
 		h1 { "👋" }
+	end
+end
+
+class ExampleSVG < Phlex::SVG
+	def template
+		svg do
+			path(d: "123")
+		end
 	end
 end
 
@@ -13,8 +21,15 @@ describe Phlex::Testing::ViewHelper do
 
 	describe "#render" do
 		it "returns the output" do
-			output = render Example.new
+			output = render ExampleHTML
 			expect(output).to be == "<h1>👋</h1>"
+		end
+	end
+
+	describe "#render with SVG" do
+		it "returns the output" do
+			output = render ExampleSVG
+			expect(output).to be == "<svg><path d=\"123\"></path></svg>"
 		end
 	end
 end

--- a/test/phlex/view/svg_tags.rb
+++ b/test/phlex/view/svg_tags.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+describe Phlex::SVG do
+	extend ViewHelper
+
+	Phlex::SVG::StandardElements::REGISTERED_ELEMENTS.each do |method_name, tag|
+		with "<#{tag}> called with an underscore prefix while overridden" do
+			svg_view do
+				define_method :template do
+					send("_#{method_name}")
+				end
+
+				define_method method_name do
+					super(class: "overridden")
+				end
+			end
+
+			it "is not overridden" do
+				expect(output).to be == %(<#{tag}></#{tag}>)
+			end
+		end
+
+		with "<#{tag}> with block content and attributes" do
+			svg_view do
+				define_method :template do
+					send(method_name, class: "class", id: "id", disabled: true, selected: false) { text { "Hello" } }
+				end
+			end
+
+			it "produces the correct output" do
+				expect(output).to be == %(<#{tag} class="class" id="id" disabled><text>Hello</text></#{tag}>)
+			end
+		end
+
+		with "<#{tag}> with block text content and attributes" do
+			svg_view do
+				define_method :template do
+					send(method_name, class: "class", id: "id", disabled: true, selected: false) { "content" }
+				end
+			end
+
+			it "produces the correct output" do
+				expect(output).to be == %(<#{tag} class="class" id="id" disabled>content</#{tag}>)
+			end
+		end
+	end
+end


### PR DESCRIPTION
Copying the same strategy as `test/phlex/view/tags.rb`. Not sure things like `svg_view` makes sense, but wanted to get the tags tested.