### PR TITLE
Rename `text` to `plain`

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -89,15 +89,21 @@ module Phlex
 		end
 
 		# Output text content. The text will be HTML-escaped.
-		def text(content)
-			@_target << ERB::Util.html_escape(
-				case content
-					when String then content
-					when Symbol then content.name
-					when Integer then content.to_s
-					else format_object(content) || content.to_s
+		def plain(content)
+			case content
+			when String
+				@_target << ERB::Util.html_escape(content)
+			when Symbol
+				@_target << ERB::Util.html_escape(content.name)
+			when Integer
+				@_target << ERB::Util.html_escape(content.to_s)
+			when nil
+				nil
+			else
+				if (formatted_object = format_object(content))
+					@_target << ERB::Util.html_escape(formatted_object)
 				end
-			)
+			end
 
 			nil
 		end
@@ -203,22 +209,8 @@ module Phlex
 
 			original_length = @_target.length
 			content = yield(self)
-			unchanged = (original_length == @_target.length)
 
-			if unchanged
-				case content
-				when String
-					@_target << ERB::Util.html_escape(content)
-				when Symbol
-					@_target << ERB::Util.html_escape(content.name)
-				when Integer
-					@_target << ERB::Util.html_escape(content.to_s)
-				else
-					if (formatted_object = format_object(content))
-						@_target << ERB::Util.html_escape(formatted_object)
-					end
-				end
-			end
+			plain(content) if original_length == @_target.length
 
 			nil
 		end
@@ -229,22 +221,7 @@ module Phlex
 
 			original_length = @_target.length
 			content = yield(*args)
-			unchanged = (original_length == @_target.length)
-
-			if unchanged
-				case content
-				when String
-					@_target << ERB::Util.html_escape(content)
-				when Symbol
-					@_target << ERB::Util.html_escape(content.name)
-				when Integer, Float
-					@_target << ERB::Util.html_escape(content.to_s)
-				else
-					if (formatted_object = format_object(content))
-						@_target << ERB::Util.html_escape(formatted_object)
-					end
-				end
-			end
+			plain(content) if original_length == @_target.length
 
 			nil
 		end

--- a/test/phlex/view/call.rb
+++ b/test/phlex/view/call.rb
@@ -5,7 +5,7 @@ describe Phlex::HTML do
 
 	view do
 		def template
-			text "Hi"
+			plain "Hi"
 		end
 	end
 
@@ -18,7 +18,7 @@ describe Phlex::HTML do
 	with "`render?` method returning false when the view context is true" do
 		view do
 			def template
-				text "Hi"
+				plain "Hi"
 			end
 
 			def render?

--- a/test/phlex/view/naughty_business.rb
+++ b/test/phlex/view/naughty_business.rb
@@ -6,7 +6,7 @@ describe Phlex::HTML do
 	with "naughty text" do
 		view do
 			def template
-				text %("><script type="text/javascript" src="bad_script.js"></script>)
+				plain %("><script type="text/javascript" src="bad_script.js"></script>)
 			end
 		end
 

--- a/test/phlex/view/new.rb
+++ b/test/phlex/view/new.rb
@@ -19,7 +19,7 @@ class ExampleWithArgs < Phlex::HTML
 	def template
 		h1 {
 			yield
-			text(", #{@name}")
+			plain(", #{@name}")
 		}
 	end
 end

--- a/test/phlex/view/text.rb
+++ b/test/phlex/view/text.rb
@@ -6,7 +6,7 @@ describe Phlex::HTML do
 	with "text" do
 		view do
 			def template
-				text "Hi"
+				plain "Hi"
 			end
 		end
 
@@ -18,7 +18,7 @@ describe Phlex::HTML do
 	with "int as text" do
 		view do
 			def template
-				text 1
+				plain 1
 			end
 		end
 
@@ -30,7 +30,7 @@ describe Phlex::HTML do
 	with "float as text" do
 		view do
 			def template
-				text 2.0
+				plain 2.0
 			end
 		end
 


### PR DESCRIPTION
Also updated `yield_content` and `yield_content_with_args` to use `plain` to keep this logic together. There's a very small performance cost to this but overall worth it.