### PR TITLE
Shim `Phlex::HTML#text` method including deprecation warning

### DIFF
--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -29,6 +29,12 @@ module Phlex
 			nil
 		end
 
+		# @deprecated use {#plain} instead.
+		def text(...)
+			warn "DEPRECATED: The `text` method has been deprecated in favour of `plain`. Please use `plain` instead. The `text` method will be removed in a future version of Phlex. Called from: #{caller.first}"
+			plain(...)
+		end
+
 		def svg(...)
 			super do
 				render Phlex::SVG.new do |svg|

--- a/test/phlex/view/text.rb
+++ b/test/phlex/view/text.rb
@@ -38,4 +38,17 @@ describe Phlex::HTML do
 			expect(output).to be == "2.0"
 		end
 	end
+
+	with "deprecated text method" do
+		view do
+			def template
+				text "Depreacted"
+			end
+		end
+
+		it "renders content and prints deprecation warning" do
+			expect(example).to receive(:warn).with("DEPRECATED: The `text` method has been deprecated in favour of `plain`. Please use `plain` instead. The `text` method will be removed in a future version of Phlex. Called from: test/phlex/view/text.rb:45:in `template'")
+			expect(output).to be == "Depreacted"
+		end
+	end
 end


### PR DESCRIPTION
That way it won't break existing HTML views in applications which are currently relying on `text`