### PR TITLE
Mention another repos on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Documentation can be found at [www.phlex.fun](https://www.phlex.fun).
 
 If you run into any trouble, please [start a discussion](https://github.com/joeldrapper/phlex/discussions/new), or [open an issue](https://github.com/joeldrapper/phlex/issues/new) if you think you’ve found a bug.
 
+### Also see
+- [joeldrapper/phlex-rails](https://github.com/joeldrapper/phlex-rails) - Ruby on Rails integration
+- [joeldrapper/phlex.fun](https://github.com/joeldrapper/phlex.fun) - Docs Website
+- [joeldrapper/phlex-markdown](https://github.com/joeldrapper/phlex-markdown) - Markdown to HTML using Phlex
+- [joeldrapper/phlex-compiler](https://github.com/joeldrapper/phlex-compiler) - A compiler for Phlex
+- [joeldrapper/phlex-translation](https://github.com/joeldrapper/phlex-translation) - I18n Support for Phlex 
+- [joeldrapper/phlex-testing-nokogiri](https://github.com/joeldrapper/phlex-testing-nokogiri) - Nokogiri support
+- [joeldrapper/phlex-testing-capybara](https://github.com/joeldrapper/phlex-testing-capybara) - Capybara support
+
 ### Community 🙌
 
 Everyone interacting in Phlex codebases, issue trackers or chat rooms is expected to follow the [code of conduct](https://github.com/joeldrapper/phlex/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Sometimes we need to enter on joeldrapper profile to find a specific repo. Adding the ecosystem repositories to README.md will help people to find or discover related repos.