### PR TITLE
Refactor away the need for storing a list of registered elements

### DIFF
--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -5,6 +5,14 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
 end
 
 module Phlex::Elements
+	private def slow_registered_elements
+		private_instance_methods
+			.lazy
+			.map(&:to_s)
+			.select { |m| m.start_with?("__phlex_") }
+			.map { |m| m[8...-2].to_sym }
+	end
+
 	def register_element(element, tag: element.name.tr("_", "-"))
 		class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
 			# frozen_string_literal: true
@@ -34,8 +42,6 @@ module Phlex::Elements
 			alias_method :_#{element}, :#{element}
 		RUBY
 
-		self::REGISTERED_ELEMENTS[element] = tag
-
 		element
 	end
 
@@ -55,8 +61,6 @@ module Phlex::Elements
 
 			alias_method :_#{element}, :#{element}
 		RUBY
-
-		self::REGISTERED_ELEMENTS[element] = tag
 
 		element
 	end

--- a/lib/phlex/html/standard_elements.rb
+++ b/lib/phlex/html/standard_elements.rb
@@ -3,8 +3,6 @@
 module Phlex::HTML::StandardElements
 	extend Phlex::Elements
 
-	REGISTERED_ELEMENTS = Concurrent::Map.new
-
 	# @!method a(**attributes, &content)
 	# 	Outputs an <code>a</code> tag
 	# 	@return [nil]

--- a/lib/phlex/html/void_elements.rb
+++ b/lib/phlex/html/void_elements.rb
@@ -3,8 +3,6 @@
 module Phlex::HTML::VoidElements
 	extend Phlex::Elements
 
-	REGISTERED_ELEMENTS = Concurrent::Map.new
-
 	# @!method area(**attributes, &content)
 	# 	Outputs an <code>area</code> tag
 	# 	@return [nil]

--- a/lib/phlex/svg/standard_elements.rb
+++ b/lib/phlex/svg/standard_elements.rb
@@ -3,8 +3,6 @@
 module Phlex::SVG::StandardElements
 	extend Phlex::Elements
 
-	REGISTERED_ELEMENTS = Concurrent::Map.new
-
 	# @!method a(**attributes, &content)
 	# 	Outputs an <code>a</code> tag
 	# 	@return [nil]

--- a/test/phlex/view/svg_tags.rb
+++ b/test/phlex/view/svg_tags.rb
@@ -3,8 +3,8 @@
 describe Phlex::SVG do
 	extend ViewHelper
 
-	Phlex::SVG::StandardElements::REGISTERED_ELEMENTS.each do |method_name, tag|
-		with "<#{tag}> called with an underscore prefix while overridden" do
+	Phlex::SVG::StandardElements.send(:slow_registered_elements).each do |method_name|
+		with "<#{method_name}> called with an underscore prefix while overridden" do
 			svg_view do
 				define_method :template do
 					send("_#{method_name}")
@@ -16,11 +16,11 @@ describe Phlex::SVG do
 			end
 
 			it "is not overridden" do
-				expect(output).to be == %(<#{tag}></#{tag}>)
+				expect(output).to be == %(<#{method_name}></#{method_name}>)
 			end
 		end
 
-		with "<#{tag}> with block content and attributes" do
+		with "<#{method_name}> with block content and attributes" do
 			svg_view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { text { "Hello" } }
@@ -28,11 +28,11 @@ describe Phlex::SVG do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{tag} class="class" id="id" disabled><text>Hello</text></#{tag}>)
+				expect(output).to be == %(<#{method_name} class="class" id="id" disabled><text>Hello</text></#{method_name}>)
 			end
 		end
 
-		with "<#{tag}> with block text content and attributes" do
+		with "<#{method_name}> with block text content and attributes" do
 			svg_view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { "content" }
@@ -40,7 +40,7 @@ describe Phlex::SVG do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{tag} class="class" id="id" disabled>content</#{tag}>)
+				expect(output).to be == %(<#{method_name} class="class" id="id" disabled>content</#{method_name}>)
 			end
 		end
 	end

--- a/test/phlex/view/tags.rb
+++ b/test/phlex/view/tags.rb
@@ -3,8 +3,11 @@
 describe Phlex::HTML do
 	extend ViewHelper
 
-	Phlex::HTML::StandardElements::REGISTERED_ELEMENTS.each do |method_name, tag|
-		with "<#{tag}> called with an underscore prefix while overridden" do
+	Phlex::HTML::StandardElements.send(:slow_registered_elements).each do |method_name|
+		# template_tag is a special case because the method_name != the tag name
+		next if method_name == :template_tag
+
+		with "<#{method_name}> called with an underscore prefix while overridden" do
 			view do
 				define_method :template do
 					send("_#{method_name}")
@@ -16,11 +19,11 @@ describe Phlex::HTML do
 			end
 
 			it "is not overridden" do
-				expect(output).to be == %(<#{tag}></#{tag}>)
+				expect(output).to be == %(<#{method_name}></#{method_name}>)
 			end
 		end
 
-		with "<#{tag}> with block content and attributes" do
+		with "<#{method_name}> with block content and attributes" do
 			view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { h1 { "Hello" } }
@@ -28,11 +31,11 @@ describe Phlex::HTML do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{tag} class="class" id="id" disabled><h1>Hello</h1></#{tag}>)
+				expect(output).to be == %(<#{method_name} class="class" id="id" disabled><h1>Hello</h1></#{method_name}>)
 			end
 		end
 
-		with "<#{tag}> with block text content and attributes" do
+		with "<#{method_name}> with block text content and attributes" do
 			view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { "content" }
@@ -40,13 +43,53 @@ describe Phlex::HTML do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{tag} class="class" id="id" disabled>content</#{tag}>)
+				expect(output).to be == %(<#{method_name} class="class" id="id" disabled>content</#{method_name}>)
 			end
 		end
 	end
 
-	Phlex::HTML::VoidElements::REGISTERED_ELEMENTS.each do |method_name, tag|
-		with "<#{tag}> called with an underscore prefix while overridden" do
+	with "<template> called with an underscore prefix while overridden" do
+		view do
+			define_method :template do
+				send("_template_tag")
+			end
+
+			define_method :template_tag do
+				super(class: "overridden")
+			end
+		end
+
+		it "is not overridden" do
+			expect(output).to be == %(<template></template>)
+		end
+	end
+
+	with "<template> with block content and attributes" do
+		view do
+			define_method :template do
+				template_tag(class: "class", id: "id", disabled: true, selected: false) { h1 { "Hello" } }
+			end
+		end
+
+		it "produces the correct output" do
+			expect(output).to be == %(<template class="class" id="id" disabled><h1>Hello</h1></template>)
+		end
+	end
+
+	with "<template> with block text content and attributes" do
+		view do
+			define_method :template do
+				template_tag(class: "class", id: "id", disabled: true, selected: false) { "content" }
+			end
+		end
+
+		it "produces the correct output" do
+			expect(output).to be == %(<template class="class" id="id" disabled>content</template>)
+		end
+	end
+
+	Phlex::HTML::VoidElements.send(:slow_registered_elements).each do |method_name|
+		with "<#{method_name}> called with an underscore prefix while overridden" do
 			view do
 				define_method :template do
 					send("_#{method_name}")
@@ -58,11 +101,11 @@ describe Phlex::HTML do
 			end
 
 			it "is not overridden" do
-				expect(output).to be == %(<#{tag}>)
+				expect(output).to be == %(<#{method_name}>)
 			end
 		end
 
-		with "<#{tag}> with attributes" do
+		with "<#{method_name}> with attributes" do
 			view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false)
@@ -70,7 +113,7 @@ describe Phlex::HTML do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{tag} class="class" id="id" disabled>)
+				expect(output).to be == %(<#{method_name} class="class" id="id" disabled>)
 			end
 		end
 	end


### PR DESCRIPTION
This fixes a case where you could not `register_element` in a module or a class that did not inherit from Phlex::HTML or Phlex::SVG.