### PR TITLE
Global capture

### DIFF
--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -34,21 +34,21 @@ module Phlex
 		end
 
 		# Renders the view and returns the buffer. The default buffer is a mutable String.
-		def call(buffer = +"", view_context: nil, parent: nil, &block)
-			__final_call__(buffer, view_context: view_context, parent: parent, &block).tap do
+		def call(buffer = nil, target: +"", view_context: nil, parent: nil, &block)
+			__final_call__(buffer, target: target, view_context: view_context, parent: parent, &block).tap do
 				self.class.rendered_at_least_once!
 			end
 		end
 
 		# @api private
-		def __final_call__(buffer = +"", view_context: nil, parent: nil, &block)
-			@_target = buffer
+		def __final_call__(buffer = nil, target: +"", view_context: nil, parent: nil, &block)
+			@_target = target
 			@_view_context = view_context
 			@_parent = parent
 
 			block ||= @_content_block
 
-			return buffer unless render?
+			return buffer || target unless render?
 
 			around_template do
 				if block
@@ -69,7 +69,7 @@ module Phlex
 				end
 			end
 
-			buffer
+			buffer ? (buffer << target) : target
 		end
 
 		# Render another view
@@ -78,10 +78,10 @@ module Phlex
 		def render(renderable, &block)
 			case renderable
 			when Phlex::SGML
-				renderable.call(@_target, view_context: @_view_context, parent: self, &block)
+				renderable.call(target: @_target, view_context: @_view_context, parent: self, &block)
 			when Class
 				if renderable < Phlex::SGML
-					renderable.new.call(@_target, view_context: @_view_context, parent: self, &block)
+					renderable.new.call(target: @_target, view_context: @_view_context, parent: self, &block)
 				end
 			else
 				raise ArgumentError, "You can't render a #{renderable}."

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -149,17 +149,18 @@ module Phlex
 		def capture(&block)
 			return "" unless block_given?
 
-			original_buffer = @_target
-			new_buffer = +""
+			original_buffer_content = @_target.dup
+			@_target.clear
 
 			begin
-				@_target = new_buffer
 				yield_content(&block)
+				new_buffer_content = @_target.dup
 			ensure
-				@_target = original_buffer
+				@_target.clear
+				@_target << original_buffer_content
 			end
 
-			new_buffer
+			new_buffer_content
 		end
 
 		# Like `capture` but the output is vanished into a BlackHole buffer.

--- a/test/phlex/view/capture.rb
+++ b/test/phlex/view/capture.rb
@@ -8,12 +8,14 @@ describe Phlex::HTML do
 			attr_accessor :captured
 
 			def template
+				h1 { "Before" }
 				@captured = capture { "Hello" }
+				h1 { "After" }
 			end
 		end
 
 		it "captures the return value" do
-			example.call
+			expect(example.call).to be == "<h1>Before</h1><h1>After</h1>"
 			expect(example.captured).to be == "Hello"
 		end
 	end
@@ -23,14 +25,16 @@ describe Phlex::HTML do
 			attr_accessor :captured
 
 			def template
+				h1 { "Before" }
 				@captured = capture do
 					h1 { "Hello" }
 				end
+				h1 { "After" }
 			end
 		end
 
 		it "captures the return value" do
-			example.call
+			expect(example.call).to be == "<h1>Before</h1><h1>After</h1>"
 			expect(example.captured).to be == "<h1>Hello</h1>"
 		end
 	end


### PR DESCRIPTION
This change allows a component to capture a block created in a different component by recycling the shared target buffer rather than creating a new temporary buffer.

It breaks the buffer contract for the target since it now needs to `dup` and `clear` the target. However, we can use the target as an internal-only buffer and write to an external output buffer to get around this. One advantage is the output buffer no longer needs to respond to `length`.

For now, the strategy is to write to the output buffer once after rendering, but it should be possible to pass it down and write to it at other times. For example, we could write to the buffer right after writing `</head>` to the internal buffer, which would be perfect for streaming responses.

I expect the internal buffer writes are too sparse to simply pass on to a stream buffer anyway.