### PR TITLE
Pre-process attributes with a class-isolated attribute cache

### DIFF
--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -20,11 +20,11 @@ module Phlex::Elements
 			def __phlex_#{element}__(**attributes, &block)
 				if attributes.length > 0
 					if block_given?
-						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[process_attributes? ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
+						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 						yield_content(&block)
 						@_target << "</#{tag}>"
 					else
-						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[process_attributes? ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
+						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
 					end
 				else
 					if block_given?
@@ -53,7 +53,7 @@ module Phlex::Elements
 
 			def __phlex_#{element}__(**attributes)
 				if attributes.length > 0
-					@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[process_attributes? ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
+					@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 				else
 					@_target << "<#{tag}>"
 				end

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -20,11 +20,11 @@ module Phlex::Elements
 			def __phlex_#{element}__(**attributes, &block)
 				if attributes.length > 0
 					if block_given?
-						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || __attributes__(**attributes)) << ">"
+						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[process_attributes? ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 						yield_content(&block)
 						@_target << "</#{tag}>"
 					else
-						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
+						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[process_attributes? ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
 					end
 				else
 					if block_given?
@@ -53,7 +53,7 @@ module Phlex::Elements
 
 			def __phlex_#{element}__(**attributes)
 				if attributes.length > 0
-					@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[attributes.hash] || __attributes__(**attributes)) << ">"
+					@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[process_attributes? ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 				else
 					@_target << "<#{tag}>"
 				end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -72,10 +72,6 @@ module Phlex
 			buffer ? (buffer << target) : target
 		end
 
-		def process_attributes?
-			false
-		end
-
 		# Render another view
 		# @param renderable [Phlex::SGML]
 		# @return [nil]
@@ -250,13 +246,13 @@ module Phlex
 		# @api private
 		private def __attributes__(**attributes)
 			__final_attributes__(**attributes).tap do |buffer|
-				Phlex::ATTRIBUTE_CACHE[process_attributes? ? (attributes.hash + self.class.hash) : attributes.hash] = buffer.freeze
+				Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] = buffer.freeze
 			end
 		end
 
 		# @api private
 		private def __final_attributes__(**attributes)
-			if process_attributes?
+			if respond_to?(:process_attributes)
 				attributes = process_attributes(**attributes)
 			end
 

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -72,6 +72,10 @@ module Phlex
 			buffer ? (buffer << target) : target
 		end
 
+		def process_attributes?
+			false
+		end
+
 		# Render another view
 		# @param renderable [Phlex::SGML]
 		# @return [nil]
@@ -246,12 +250,16 @@ module Phlex
 		# @api private
 		private def __attributes__(**attributes)
 			__final_attributes__(**attributes).tap do |buffer|
-				Phlex::ATTRIBUTE_CACHE[attributes.hash] = buffer.freeze
+				Phlex::ATTRIBUTE_CACHE[process_attributes? ? (attributes.hash + self.class.hash) : attributes.hash] = buffer.freeze
 			end
 		end
 
 		# @api private
 		private def __final_attributes__(**attributes)
+			if process_attributes?
+				attributes = process_attributes(**attributes)
+			end
+
 			if attributes[:href]&.start_with?(/\s*javascript:/)
 				attributes.delete(:href)
 			end

--- a/test/phlex/view/process_attributes.rb
+++ b/test/phlex/view/process_attributes.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe Phlex::HTML do
+	extend ViewHelper
+
+	view do
+		def template
+			div(class: "foo")
+		end
+
+		def process_attributes(**attributes)
+			attributes.transform_values { |v| "#{v}-bar" }
+		end
+	end
+
+	it "works" do
+		expect(output).to be == %(<div class="foo-bar"></div>)
+	end
+end


### PR DESCRIPTION
Allow users to define custom attribute processing logic on component classes by defining `process_attributes(**attributes)`.

When this method is defined, the attributes cache will include the component class as part of the cache key, so the cache is isolated for each distinct class. While attribute processing can be different for each component class, it should _always_ be deterministic because the cache will still be based on the original unprocessed Hash.

### Performance

Introducing this feature brings ~1% performance cost for classes that don't opt in to using the feature by defining `process_attributes` and ~10% performance cost for classes that do use the feature.

### Security

The contract with `process_attributes` is that it takes keyword arguments and returns a Hash. Since this Hash then goes through Phlex own `__attributes__` processor, it doesn't bypass any built in security features.

Closes #467 