### PR TITLE
Improve `capture` memory usage

### DIFF
--- a/lib/phlex/unbuffered.rb
+++ b/lib/phlex/unbuffered.rb
@@ -24,7 +24,7 @@ class Phlex::Unbuffered < BasicObject
 		if @object.respond_to?(name)
 
 			__class__.define_method(name) do |*a, **k, &b|
-				@object.capture { @object.public_send(name, *a, **k, &b) }
+				@object.local_capture { @object.public_send(name, *a, **k, &b) }
 			end
 
 			# Now we've defined this missing method, we can call it.

--- a/test/phlex/view/capture.rb
+++ b/test/phlex/view/capture.rb
@@ -20,6 +20,20 @@ describe Phlex::HTML do
 		end
 	end
 
+	if RUBY_ENGINE == "ruby"
+		with "a c-level proc" do
+			view do
+				def template
+					capture(&:div)
+				end
+			end
+
+			it "raises an argument error" do
+				expect { example.call }.to raise_exception Phlex::ArgumentError
+			end
+		end
+	end
+
 	with "a block" do
 		view do
 			attr_accessor :captured


### PR DESCRIPTION
Unfortunately, the technique used for #513 uses a significant amount of memory. This PR provides the same features with a different technique.

`capture` is now split into `local_capture` and `capture`.

`local_capture` uses the original technique of temporarily pointing to a new buffer while yielding a block. `local_capture` is the fastest option for capturing when you know the block is on `self` or returns a String (e.g. a block from ERB).

`capture` checks the block's receiver, and if it's a `Phlex::SGML`, calls `local_capture` on the receiver rather than `self`. Unfortunately, this makes it incompatible with C-Level Procs (from `&:symbol`).

There is no decent way to detect if a Proc is a C-level Proc, since calling `binding` raises an `ArgumentError`. I’ve opened an [issue](https://bugs.ruby-lang.org/issues/19484) recommending C-level Procs respond to `binding` with `nil`.