### PR TITLE
Introduce global context

### DIFF
--- a/lib/phlex/context.rb
+++ b/lib/phlex/context.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class Phlex::Context
+	def initialize
+		@target = +""
+	end
+
+	attr_accessor :target
+
+	def with_target(new_target)
+		original_target = @target
+
+		begin
+			@target = new_target
+			yield
+		ensure
+			@target = original_target
+		end
+
+		new_target
+	end
+end

--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -20,19 +20,19 @@ module Phlex::Elements
 			def __phlex_#{element}__(**attributes, &block)
 				if attributes.length > 0 # with attributes
 					if block_given? # with content block
-						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
+						@_context.target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 						yield_content(&block)
-						@_target << "</#{tag}>"
+						@_context.target << "</#{tag}>"
 					else # without content block
-						@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
+						@_context.target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
 					end
 				else # without attributes
 					if block_given? # with content block
-						@_target << "<#{tag}>"
+						@_context.target << "<#{tag}>"
 						yield_content(&block)
-						@_target << "</#{tag}>"
+						@_context.target << "</#{tag}>"
 					else # without content block
-						@_target << "<#{tag}></#{tag}>"
+						@_context.target << "<#{tag}></#{tag}>"
 					end
 				end
 
@@ -53,9 +53,9 @@ module Phlex::Elements
 
 			def __phlex_#{element}__(**attributes)
 				if attributes.length > 0 # with attributes
-					@_target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
+					@_context.target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 				else # without attributes
-					@_target << "<#{tag}>"
+					@_context.target << "<#{tag}>"
 				end
 
 				nil

--- a/lib/phlex/html.rb
+++ b/lib/phlex/html.rb
@@ -25,7 +25,7 @@ module Phlex
 
 		# Output an HTML doctype.
 		def doctype
-			@_target << "<!DOCTYPE html>"
+			@_context.target << "<!DOCTYPE html>"
 			nil
 		end
 


### PR DESCRIPTION
In an alternative approach to #524, here we introduce a render-global context that keeps track of the current target buffer. `capture` can change the buffer on context, and it's reflected in every component in the render tree that reference the same context.