### PR TITLE
Improved element register

### DIFF
--- a/lib/phlex/element_clobbering_guard.rb
+++ b/lib/phlex/element_clobbering_guard.rb
@@ -3,11 +3,11 @@
 module Phlex
 	module ElementClobberingGuard
 		def method_added(method_name)
-			if method_name[0] == "_" && private_instance_methods.include?(:"__phlex#{method_name}__")
+			if method_name[0] == "_" && element_method?(method_name[1..].to_sym)
 				raise NameError, "👋 Redefining the method `#{name}##{method_name}` is not a good idea."
+			else
+				super
 			end
-
-			super
 		end
 	end
 end

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -29,6 +29,16 @@ module Phlex
 				alias_method :__attributes__, :__final_attributes__
 				alias_method :call, :__final_call__
 			end
+
+			def element_method?(method_name)
+				return false unless instance_methods.include?(method_name)
+
+				owner = instance_method(method_name).owner
+
+				return true if owner.is_a?(Phlex::Elements) && owner.registered_elements[method_name]
+
+				false
+			end
 		end
 
 		# Renders the view and returns the buffer. The default buffer is a mutable String.

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -30,6 +30,7 @@ module Phlex
 				alias_method :call, :__final_call__
 			end
 
+			# @api private
 			def element_method?(method_name)
 				return false unless instance_methods.include?(method_name)
 

--- a/test/phlex/view/svg_tags.rb
+++ b/test/phlex/view/svg_tags.rb
@@ -3,24 +3,24 @@
 describe Phlex::SVG do
 	extend ViewHelper
 
-	Phlex::SVG::StandardElements.send(:slow_registered_elements).each do |method_name|
-		with "<#{method_name}> called with an underscore prefix while overridden" do
+	Phlex::SVG::StandardElements.registered_elements.each do |method_name, tag|
+		with "<#{tag}> called with an underscore prefix while overridden" do
 			svg_view do
 				define_method :template do
 					send("_#{method_name}")
 				end
 
-				define_method method_name do
+				define_method tag do
 					super(class: "overridden")
 				end
 			end
 
 			it "is not overridden" do
-				expect(output).to be == %(<#{method_name}></#{method_name}>)
+				expect(output).to be == %(<#{tag}></#{tag}>)
 			end
 		end
 
-		with "<#{method_name}> with block content and attributes" do
+		with "<#{tag}> with block content and attributes" do
 			svg_view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { text { "Hello" } }
@@ -28,11 +28,11 @@ describe Phlex::SVG do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{method_name} class="class" id="id" disabled><text>Hello</text></#{method_name}>)
+				expect(output).to be == %(<#{tag} class="class" id="id" disabled><text>Hello</text></#{tag}>)
 			end
 		end
 
-		with "<#{method_name}> with block text content and attributes" do
+		with "<#{tag}> with block text content and attributes" do
 			svg_view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { "content" }
@@ -40,7 +40,7 @@ describe Phlex::SVG do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{method_name} class="class" id="id" disabled>content</#{method_name}>)
+				expect(output).to be == %(<#{tag} class="class" id="id" disabled>content</#{tag}>)
 			end
 		end
 	end

--- a/test/phlex/view/tags.rb
+++ b/test/phlex/view/tags.rb
@@ -3,11 +3,8 @@
 describe Phlex::HTML do
 	extend ViewHelper
 
-	Phlex::HTML::StandardElements.send(:slow_registered_elements).each do |method_name|
-		# template_tag is a special case because the method_name != the tag name
-		next if method_name == :template_tag
-
-		with "<#{method_name}> called with an underscore prefix while overridden" do
+	Phlex::HTML::StandardElements.registered_elements.each do |method_name, tag|
+		with "<#{tag}> called with an underscore prefix while overridden" do
 			view do
 				define_method :template do
 					send("_#{method_name}")
@@ -19,11 +16,11 @@ describe Phlex::HTML do
 			end
 
 			it "is not overridden" do
-				expect(output).to be == %(<#{method_name}></#{method_name}>)
+				expect(output).to be == %(<#{tag}></#{tag}>)
 			end
 		end
 
-		with "<#{method_name}> with block content and attributes" do
+		with "<#{tag}> with block content and attributes" do
 			view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { h1 { "Hello" } }
@@ -31,11 +28,11 @@ describe Phlex::HTML do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{method_name} class="class" id="id" disabled><h1>Hello</h1></#{method_name}>)
+				expect(output).to be == %(<#{tag} class="class" id="id" disabled><h1>Hello</h1></#{tag}>)
 			end
 		end
 
-		with "<#{method_name}> with block text content and attributes" do
+		with "<#{tag}> with block text content and attributes" do
 			view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false) { "content" }
@@ -43,69 +40,29 @@ describe Phlex::HTML do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{method_name} class="class" id="id" disabled>content</#{method_name}>)
+				expect(output).to be == %(<#{tag} class="class" id="id" disabled>content</#{tag}>)
 			end
 		end
 	end
 
-	with "<template> called with an underscore prefix while overridden" do
-		view do
-			define_method :template do
-				send("_template_tag")
-			end
-
-			define_method :template_tag do
-				super(class: "overridden")
-			end
-		end
-
-		it "is not overridden" do
-			expect(output).to be == %(<template></template>)
-		end
-	end
-
-	with "<template> with block content and attributes" do
-		view do
-			define_method :template do
-				template_tag(class: "class", id: "id", disabled: true, selected: false) { h1 { "Hello" } }
-			end
-		end
-
-		it "produces the correct output" do
-			expect(output).to be == %(<template class="class" id="id" disabled><h1>Hello</h1></template>)
-		end
-	end
-
-	with "<template> with block text content and attributes" do
-		view do
-			define_method :template do
-				template_tag(class: "class", id: "id", disabled: true, selected: false) { "content" }
-			end
-		end
-
-		it "produces the correct output" do
-			expect(output).to be == %(<template class="class" id="id" disabled>content</template>)
-		end
-	end
-
-	Phlex::HTML::VoidElements.send(:slow_registered_elements).each do |method_name|
-		with "<#{method_name}> called with an underscore prefix while overridden" do
+	Phlex::HTML::VoidElements.registered_elements.each do |method_name, tag|
+		with "<#{tag}> called with an underscore prefix while overridden" do
 			view do
 				define_method :template do
 					send("_#{method_name}")
 				end
 
-				define_method method_name do
+				define_method tag do
 					super(class: "overridden")
 				end
 			end
 
 			it "is not overridden" do
-				expect(output).to be == %(<#{method_name}>)
+				expect(output).to be == %(<#{tag}>)
 			end
 		end
 
-		with "<#{method_name}> with attributes" do
+		with "<#{tag}> with attributes" do
 			view do
 				define_method :template do
 					send(method_name, class: "class", id: "id", disabled: true, selected: false)
@@ -113,7 +70,7 @@ describe Phlex::HTML do
 			end
 
 			it "produces the correct output" do
-				expect(output).to be == %(<#{method_name} class="class" id="id" disabled>)
+				expect(output).to be == %(<#{tag} class="class" id="id" disabled>)
 			end
 		end
 	end


### PR DESCRIPTION
### Listing registered elements
`Phlex::Element` classes (such as `Phlex::HTML::StandardElements`) now respond to `registered_elements` with a `Concurrent::Map(method_name => Symbol, tag => String)` of all their registered elements.

### Checking if a method is a registered element
`Phlex::SGML` classes (`Phlex::HTML` and `Phlex::SGML`) now also respond to `registered_element?(method_name => Symbol) => bool`. This works by looking up the method and asking its _owner_ if it's a registered element.

Note: this second method is part of Phlex’ private API.