### PR TITLE
Avoid redundant `@_context.target` calls

### DIFF
--- a/lib/phlex/elements.rb
+++ b/lib/phlex/elements.rb
@@ -18,21 +18,23 @@ module Phlex::Elements
 			# frozen_string_literal: true
 
 			def __phlex_#{element}__(**attributes, &block)
+				target = @_context.target
+			#{'	'}
 				if attributes.length > 0 # with attributes
 					if block_given? # with content block
-						@_context.target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
+						target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 						yield_content(&block)
-						@_context.target << "</#{tag}>"
+						target << "</#{tag}>"
 					else # without content block
-						@_context.target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
+						target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << "></#{tag}>"
 					end
 				else # without attributes
 					if block_given? # with content block
-						@_context.target << "<#{tag}>"
+						target << "<#{tag}>"
 						yield_content(&block)
-						@_context.target << "</#{tag}>"
+						target << "</#{tag}>"
 					else # without content block
-						@_context.target << "<#{tag}></#{tag}>"
+						target << "<#{tag}></#{tag}>"
 					end
 				end
 
@@ -52,10 +54,12 @@ module Phlex::Elements
 			# frozen_string_literal: true
 
 			def __phlex_#{element}__(**attributes)
+				target = @_context.target
+			#{'	'}
 				if attributes.length > 0 # with attributes
-					@_context.target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
+					target << "<#{tag}" << (Phlex::ATTRIBUTE_CACHE[respond_to?(:process_attributes) ? (attributes.hash + self.class.hash) : attributes.hash] || __attributes__(**attributes)) << ">"
 				else # without attributes
-					@_context.target << "<#{tag}>"
+					target << "<#{tag}>"
 				end
 
 				nil

--- a/lib/phlex/sgml.rb
+++ b/lib/phlex/sgml.rb
@@ -116,11 +116,13 @@ module Phlex
 		# Output a whitespace character. This is useful for getting inline elements to wrap. If you pass a block, a whitespace will be output before and after yielding the block.
 		# @return [nil]
 		def whitespace
-			@_context.target << " "
+			target = @_context.target
+
+			target << " "
 
 			if block_given?
 				yield
-				@_context.target << " "
+				target << " "
 			end
 
 			nil
@@ -129,9 +131,11 @@ module Phlex
 		# Output an HTML comment.
 		# @return [nil]
 		def comment(&block)
-			@_context.target << "<!-- "
+			target = @_context.target
+
+			target << "<!-- "
 			yield_content(&block)
-			@_context.target << " -->"
+			target << " -->"
 
 			nil
 		end
@@ -208,10 +212,11 @@ module Phlex
 		private def yield_content
 			return unless block_given?
 
-			original_length = @_context.target.length
-			content = yield(self)
+			target = @_context.target
 
-			plain(content) if original_length == @_context.target.length
+			original_length = target.length
+			content = yield(self)
+			plain(content) if original_length == target.length
 
 			nil
 		end
@@ -221,9 +226,11 @@ module Phlex
 		private def yield_content_with_args(*args)
 			return unless block_given?
 
-			original_length = @_context.target.length
+			target = @_context.target
+
+			original_length = target.length
 			content = yield(*args)
-			plain(content) if original_length == @_context.target.length
+			plain(content) if original_length == target.length
 
 			nil
 		end


### PR DESCRIPTION
We don’t need to call `@_context.target` multiple times in the same method.