### PR TITLE
Update around_row to forward all arguments to row_template

### DIFF
--- a/.rubocop-https---www-goodcop-style-rubocop-yml
+++ b/.rubocop-https---www-goodcop-style-rubocop-yml
@@ -1,0 +1,188 @@
+AllCops:
+  NewCops: enable
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Layout/ArgumentAlignment:
+  Enabled: false
+
+Layout/ArrayAlignment:
+  Enabled: false
+
+Layout/CaseIndentation:
+  Enabled: false
+
+Layout/CommentIndentation:
+  AllowForAlignment: true
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+
+Layout/HashAlignment:
+  Enabled: false
+
+Layout/LineLength:
+  Enabled: false
+
+Layout/MultilineMethodCallBraceLayout:
+  Enabled: false
+
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+Layout/SingleLineBlockChain:
+  Enabled: false
+
+Layout/SpaceInLambdaLiteral:
+  EnforcedStyle: require_space
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+
+Lint/EmptyClass:
+  AllowComments: true
+
+Lint/MissingSuper:
+  Enabled: false
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: false
+
+Lint/UnusedMethodArgument:
+  Enabled: false
+
+Metrics:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+
+Naming/ConstantName:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
+Naming/MethodParameterName:
+  MinNameLength: 1
+
+Style/AccessModifierDeclarations:
+  Enabled: false
+
+Style/AccessorGrouping:
+  Enabled: false
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
+Style/BeginBlock:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
+
+Style/CaseEquality:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/ClassCheck:
+  Enabled: false
+
+Style/ClassMethodsDefinitions:
+  Enabled: false
+
+Style/ConditionalAssignment:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false
+
+Style/EmptyCaseCondition:
+  Enabled: false
+
+Style/EmptyMethod:
+  Enabled: false
+
+Style/EndBlock:
+  Enabled: false
+
+Style/FetchEnvVar:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: false
+
+Style/KeywordParametersOrder:
+  Enabled: false
+
+Style/MixinGrouping:
+  Enabled: false
+
+Style/ModuleFunction:
+  Enabled: false
+
+Style/MultilineMemoization:
+  Enabled: false
+
+Style/MultipleComparison:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/NumberedParametersLimit:
+  Enabled: false
+
+Style/NumericLiterals:
+  Enabled: false
+
+Style/NumericPredicate:
+  Enabled: false
+
+Style/ParallelAssignment:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  Enabled: false
+
+Style/RedundantAssignment:
+  Enabled: false
+
+Style/Semicolon:
+  AllowAsExpressionSeparator: true
+
+Style/Send:
+  Enabled: false
+
+Style/StringConcatenation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Style/ZeroLengthPredicate:
+  Enabled: false

--- a/lib/phlex/csv.rb
+++ b/lib/phlex/csv.rb
@@ -113,8 +113,8 @@ class Phlex::CSV
 		buffer
 	end
 
-	def around_row(item)
-		row_template(item)
+	def around_row(...)
+		row_template(...)
 	end
 
 	def filename

--- a/quickdraw/csv.test.rb
+++ b/quickdraw/csv.test.rb
@@ -111,6 +111,33 @@ test "no headers" do
 	CSV
 end
 
+test "with a custom around_row" do
+	example = Class.new(Phlex::CSV) do
+		def escape_csv_injection? = true
+
+		def around_row(item)
+			super(item.name, item.price)
+		end
+
+		def row_template(name, price)
+			column "Name", name
+			column "Price", price
+		end
+	end
+
+	assert_equal example.new(products).call, <<~CSV
+		Name,Price
+		Apple,1.0
+		" Banana ",2.0
+		strawberry,Three pounds
+		"'=SUM(A1:B1)","'=SUM(A1:B1)"
+		"Abc, ""def""","Foo
+		bar ""baz"""
+		"",""
+		"",""
+	CSV
+end
+
 test "with a custom delimiter defined as a method" do
 	example = Class.new(Phlex::CSV) do
 		define_method(:escape_csv_injection?) { true }


### PR DESCRIPTION
Previously, one of the uses of the `yielder` override in `Phlex::CSV` was to change the argument signature provided to the `row_template` method. The new `around_row` was not allowing for any modifications to the argument structure.