### PR TITLE
Fix failure in `quickdraw/sgml/attributes.test.rb` when running tests locally

### DIFF
--- a/quickdraw/sgml/attributes.test.rb
+++ b/quickdraw/sgml/attributes.test.rb
@@ -182,7 +182,7 @@ test "_, Date" do
 end
 
 test "_, Time" do
-	output = phlex { div(attribute: Time.new(2023, 1, 15, 12, 30, 45)) }
+	output = phlex { div(attribute: Time.new(2023, 1, 15, 12, 30, 45, "+00:00")) }
 	assert_equal_html output, %(<div attribute="2023-01-15T12:30:45+00:00"></div>)
 end
 


### PR DESCRIPTION
```sh
phlex$ bundle exec qt
...
(./quickdraw/sgml/attributes.test.rb)
  ./quickdraw/sgml/attributes.test.rb:184
    _, Time
      ./quickdraw/sgml/attributes.test.rb:186

Expected HTML strings to be equal (compared with `actual == expected`):

Actual                                                Expected
1 <div attribute="2023-01-15T12:30:45-06:00"></div>   1 <div attribute="2023-01-15T12:30:45+00:00"></div>

Passed: 1630 | Failed: 1 | Errors: 0
```

The test asserts a zero offset, but `Time.new` defaults to the local timezone, which may be different.

https://docs.ruby-lang.org/en/3.4/Time.html#method-c-new