### PR TITLE
Simplify buffering compilation

### DIFF
--- a/lib/phlex/compiler/method_compiler.rb
+++ b/lib/phlex/compiler/method_compiler.rb
@@ -364,6 +364,8 @@ module Phlex::Compiler
 		end
 
 		private def buffer(node)
+			node => Refract::StringNode | Refract::EmbeddedStatementsNode
+
 			if @current_buffer
 				@current_buffer << node
 


### PR DESCRIPTION
With this change, there are three ways to buffer.

1. `buffer` takes a `StringNode` or an `EmbeddedStatementsNode`, adds it to the current buffer and outputs `nil`. If there is no current buffer, it creates one and outputs an `InterpolatedStringNode` that references it.
2. `raw` takes a `String` and converts it to a raw `StringNode` buffer.
3. `plain` takes a `String` and HTML escapes it at compile time then passes it to `raw`.
4. `interpolate` takes any Node and wraps it in an `EmbeddedStatementsNode`, then passes it to `buffer`.